### PR TITLE
docs: establish v2 issue and PR workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Issue
+
+Closes #
+
+## Scope
+
+-
+
+## Verification
+
+- [ ] Relevant automated checks pass
+- [ ] UI or data behavior was validated where applicable
+- [ ] No unrelated local changes are included
+- [ ] Durable decisions are recorded in `workspace/second-brain` where applicable
+
+## Risks and deferred work
+
+-
+
+## Handoff
+
+- [ ] Issue has the `v2` label and belongs to Project 1
+- [ ] Project item is set to `In review`
+- [ ] PR is left unmerged for maintainer review

--- a/docs/replacement-app/github-workflow.md
+++ b/docs/replacement-app/github-workflow.md
@@ -1,0 +1,49 @@
+# Replacement App GitHub Workflow
+
+All work on the containerized replacement application is issue-first and is delivered through pull
+requests. Legacy ToolJet work remains visible in the same repository but is not part of this workflow
+unless it is explicitly migrated into a new v2 issue.
+
+## Before implementation
+
+1. Create a focused GitHub issue or select an existing issue that fully covers the requested change.
+2. Add the issue to the organization project:
+   `Studio-Animal-Aided-Design/projects/1`.
+3. Apply the `v2` label and the appropriate `area:*`, `type:*`, and `priority:*` labels.
+4. Set the project status to `In progress` when implementation starts.
+5. Create a dedicated branch from the current default branch.
+
+Use branch names that include the issue number and a short English description:
+
+- `feat/72-public-catalogue`
+- `fix/73-species-portrait-layout`
+- `chore/81-v2-workflow`
+
+If a new request spans independent deliverables, split it into separate issues and branches. Do not
+expand an active issue silently.
+
+## During implementation
+
+- Keep changes within the issue scope.
+- Preserve unrelated local changes and never include them in the commit.
+- Record durable architecture, schema, workflow, and migration decisions in `workspace/second-brain`.
+- Run verification appropriate to the affected surface before publishing the branch.
+- Add follow-up work as issues instead of hiding it in comments or unrelated commits.
+
+## Pull request handoff
+
+1. Commit only the files belonging to the issue.
+2. Push the dedicated branch.
+3. Open a draft pull request against `main` unless the user explicitly requests a ready-for-review PR.
+4. Reference the issue in the PR body with `Closes #<issue-number>`.
+5. Summarize scope, verification, risks, and intentionally deferred work.
+6. Move the project item to `In review`.
+7. Leave the merge to the repository maintainer. Codex must not merge into `main`.
+
+## Definition of done
+
+- The issue has the `v2` label and belongs to Project 1.
+- The change is implemented and verified on its own branch.
+- A PR references the issue and contains no unrelated changes.
+- Project status reflects the current lifecycle state.
+- Required second-brain documentation is updated.


### PR DESCRIPTION
## Issue

Closes #81

## Scope

- document the issue-first workflow for replacement-app work
- require the `v2` label and Project 1 assignment
- define issue-numbered branches and PR handoff without merging
- add a pull request template that checks scope, verification, and project status

## Verification

- `v2` label created and applied to #71-#81
- #71-#81 added to Studio Animal-Aided-Design Project 1
- staged diff checked for whitespace errors
- existing unrelated local changes excluded from the commit

## Risks and deferred work

- project status and sizing for the existing #71-#80 backlog can be refined ticket by ticket when work starts

## Handoff

This PR is intentionally left as a draft and unmerged for maintainer review.