### PR TITLE
Public editorial foundation

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -10,6 +10,27 @@
   --paper: #fffdf8;
   --line: #d9dfd8;
   --orange: #e06c3d;
+  --color-text: var(--ink);
+  --color-text-muted: var(--ink-soft);
+  --color-surface-brand: var(--forest);
+  --color-surface-page: var(--cream);
+  --color-surface-paper: var(--paper);
+  --color-accent: var(--orange);
+  --color-border: var(--line);
+  --font-interface: Arial, Helvetica, sans-serif;
+  --font-editorial: Georgia, "Times New Roman", serif;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --radius-control: 999px;
+  --radius-card: 20px;
+  --radius-section: 24px;
+  --shadow-floating: 0 12px 35px rgba(30, 66, 57, .08);
+  --content-wide: 1480px;
 }
 
 * { box-sizing: border-box; }
@@ -18,17 +39,22 @@ body {
   margin: 0;
   background: var(--cream);
   color: var(--ink);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-interface);
   -webkit-font-smoothing: antialiased;
 }
 a { color: inherit; text-decoration: none; }
 button, input, select, textarea { font: inherit; }
 button, a { -webkit-tap-highlight-color: transparent; }
+::selection { background: var(--lime); color: var(--ink); }
+:where(a, button, input, select, textarea, summary):focus-visible {
+  outline: 3px solid var(--orange);
+  outline-offset: 3px;
+}
 .sr-only {
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
   overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
 }
-.page-shell { width: min(1480px, calc(100% - 32px)); margin: 16px auto 0; }
+.page-shell { width: min(var(--content-wide), calc(100% - 32px)); margin: 16px auto 0; }
 .site-header {
   height: 82px; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center;
   padding: 0 28px; border: 1px solid rgba(23, 53, 46, .1); border-radius: 18px;
@@ -48,7 +74,7 @@ button, a { -webkit-tap-highlight-color: transparent; }
   border-radius: 24px; border: 1px solid rgba(23,53,46,.08);
 }
 .hero-copy { padding: clamp(58px, 6vw, 92px); padding-right: 24px; display: flex; flex-direction: column; justify-content: center; position: relative; z-index: 5; }
-.kicker, .eyebrow { text-transform: uppercase; letter-spacing: .16em; font-size: 11px; font-weight: 800; color: var(--forest); }
+.kicker, .eyebrow, .editorial-eyebrow { margin-top: 0; text-transform: uppercase; letter-spacing: .16em; font-size: 11px; font-weight: 800; color: var(--forest); }
 .kicker { display: flex; align-items: center; gap: 7px; }
 .hero h1, .catalog-intro h1, .portrait-heading h1 {
   font-family: Georgia, "Times New Roman", serif; font-weight: 400; letter-spacing: -.055em; line-height: .92;
@@ -62,6 +88,7 @@ h1 em, h2 em { color: var(--orange); font-weight: 400; }
   box-shadow: 0 12px 35px rgba(30, 66, 57, .08);
 }
 .search-box input { min-width: 0; border: 0; outline: 0; color: var(--ink); }
+.search-box:focus-within { border-color: var(--orange); box-shadow: 0 0 0 3px rgba(224,108,61,.16), var(--shadow-floating); }
 .search-box button, .primary-link {
   border: 0; background: var(--forest); color: white; padding: 13px 22px; border-radius: 999px; cursor: pointer; font-weight: 700;
 }
@@ -117,11 +144,20 @@ h1 em, h2 em { color: var(--orange); font-weight: 400; }
   50% { translate: 0 -8px; }
 }
 .section { padding: 120px clamp(20px, 6vw, 88px); }
-.section-heading { display: flex; justify-content: space-between; align-items: end; margin-bottom: 42px; gap: 30px; }
-.section-heading h2, .relationship-copy h2, .portrait-section h2, .lifecycle-section h2, .planning-section h2 {
+.section-heading, .editorial-section-heading { display: flex; justify-content: space-between; align-items: end; margin-bottom: 42px; gap: 30px; }
+.section-heading h2, .editorial-section-heading h2, .relationship-copy h2, .portrait-section h2, .lifecycle-section h2, .planning-section h2 {
   font-family: Georgia, serif; font-size: clamp(38px, 4vw, 62px); line-height: 1.05; font-weight: 400; letter-spacing: -.035em; max-width: 850px; margin: 12px 0 0;
 }
-.outline-link { display: inline-flex; align-items: center; gap: 8px; padding: 12px 18px; border: 1px solid #adc0b8; border-radius: 999px; font-size: 13px; font-weight: 700; white-space: nowrap; }
+.editorial-lede { max-width: 680px; margin: 18px 0 0; color: var(--ink-soft); font-size: 17px; line-height: 1.65; }
+.editorial-section-action { flex: 0 0 auto; }
+.outline-link, .editorial-action { display: inline-flex; align-items: center; justify-content: center; gap: 8px; min-height: 44px; padding: 12px 18px; border: 1px solid #adc0b8; border-radius: var(--radius-control); font-size: 13px; font-weight: 700; white-space: nowrap; transition: color .2s ease, background .2s ease, border-color .2s ease, transform .2s ease; }
+.editorial-action-primary { border-color: var(--forest); background: var(--forest); color: white; }
+.editorial-action-outline { background: transparent; }
+.editorial-action-text { min-height: auto; padding: 6px 0; border-color: transparent; color: var(--forest); }
+.editorial-action:hover { transform: translateY(-1px); }
+.editorial-action-primary:hover { background: #0d4034; }
+.editorial-action-outline:hover { background: var(--mint); }
+.editorial-action-text:hover { color: var(--orange); }
 .species-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
 .species-card { overflow: hidden; border-radius: 20px; background: var(--paper); border: 1px solid rgba(23,53,46,.1); }
 .species-image { height: 330px; display: block; position: relative; overflow: hidden; background: #d9e3dd; }
@@ -131,7 +167,7 @@ h1 em, h2 em { color: var(--orange); font-weight: 400; }
 .species-card-content { padding: 28px; }
 .species-card h3 { font-family: Georgia, serif; font-size: 33px; font-weight: 400; margin: 6px 0 0; }
 .scientific, .portrait-scientific { font-family: Georgia, serif; font-style: italic; color: var(--ink-soft); }
-.species-card-content > p:not(.eyebrow):not(.scientific) { color: var(--ink-soft); line-height: 1.55; min-height: 72px; }
+.species-card-content > p:not(.eyebrow):not(.editorial-eyebrow):not(.scientific) { color: var(--ink-soft); line-height: 1.55; min-height: 72px; }
 .text-link { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 800; margin-top: 12px; color: var(--forest); }
 .relationship-section { display: grid; grid-template-columns: minmax(0, .82fr) minmax(0, 1.18fr); min-height: 600px; background: #dcead4; border-radius: 24px; overflow: hidden; }
 .relationship-copy { padding: clamp(55px, 7vw, 100px); display: flex; flex-direction: column; justify-content: center; }
@@ -243,7 +279,7 @@ footer div { display: flex; gap: 18px; }
 
 .catalog-intro { padding: 100px clamp(20px, 6vw, 88px) 55px; }
 .catalog-intro h1 { font-size: clamp(60px, 7vw, 105px); margin: 22px 0 28px; }
-.catalog-intro > p:not(.eyebrow) { color: var(--ink-soft); font-size: 17px; }
+.catalog-intro > p:not(.eyebrow):not(.editorial-eyebrow) { color: var(--ink-soft); font-size: 17px; }
 .catalog-toolbar { display: grid; grid-template-columns: auto 1fr auto auto; align-items: center; gap: 12px; max-width: 860px; margin-top: 36px; border-bottom: 1px solid var(--ink); padding: 14px 0; }
 .catalog-toolbar input { border: 0; background: transparent; outline: 0; }
 .catalog-toolbar button, .catalog-toolbar select { border: 1px solid var(--line); border-radius: 999px; background: var(--paper); padding: 9px 13px; color: var(--ink); }
@@ -253,6 +289,10 @@ footer div { display: flex; gap: 18px; }
 .empty-state { margin: 0 clamp(20px, 6vw, 88px) 100px; padding: 80px; border: 1px dashed #9eb2a8; border-radius: 22px; text-align: center; background: rgba(255,253,248,.5); }
 .empty-state h2 { font: 400 clamp(30px,4vw,52px)/1.1 Georgia,serif; max-width: 720px; margin: 12px auto 28px; }
 .empty-state .outline-link { display: inline-flex; }
+.editorial-empty-state { margin: 0 clamp(20px, 6vw, 88px) 100px; padding: clamp(48px, 7vw, 80px); border: 1px dashed #9eb2a8; border-radius: var(--radius-card); text-align: center; background: rgba(255,253,248,.58); }
+.editorial-empty-state h2 { max-width: 720px; margin: 12px auto 18px; font: 400 clamp(30px,4vw,52px)/1.1 var(--font-editorial); }
+.editorial-empty-state > p:not(.editorial-eyebrow) { max-width: 580px; margin: 0 auto; color: var(--ink-soft); line-height: 1.65; }
+.editorial-empty-action { margin-top: 28px; }
 .breadcrumb { display: flex; justify-content: space-between; align-items: center; padding: 34px 12px; font-size: 12px; text-transform: uppercase; letter-spacing: .1em; }
 .breadcrumb a { display: flex; gap: 7px; align-items: center; }
 .portrait-hero { display: grid; grid-template-columns: 1fr 1fr; min-height: 690px; background: var(--paper); border-radius: 24px; overflow: hidden; }
@@ -314,7 +354,7 @@ footer div { display: flex; gap: 18px; }
 .botanical-mark i:last-child { width: 160px; height: 160px; background: rgba(220,237,144,.55); border: 0; }
 .entity-card-content { padding: 28px; }
 .entity-card-content h2 { font: 400 33px/1.05 Georgia,serif; margin: 7px 0; }
-.entity-card-content > p:not(.eyebrow):not(.scientific) { color: var(--ink-soft); line-height: 1.55; min-height: 72px; }
+.entity-card-content > p:not(.eyebrow):not(.editorial-eyebrow):not(.scientific) { color: var(--ink-soft); line-height: 1.55; min-height: 72px; }
 .entity-detail-hero { display: grid; grid-template-columns: 1fr 1fr; min-height: 690px; overflow: hidden; border-radius: 24px; background: var(--paper); }
 .entity-detail-heading { padding: clamp(50px,7vw,96px); display: flex; flex-direction: column; justify-content: center; }
 .entity-detail-heading h1 { font: 400 clamp(64px,7vw,108px)/.92 Georgia,serif; letter-spacing: -.05em; margin: 10px 0; }
@@ -345,6 +385,15 @@ footer div { display: flex; gap: 18px; }
 .related-link-grid small { text-transform: uppercase; letter-spacing: .1em; color: var(--orange); font-size: 9px; }
 .related-link-grid i { font: italic 12px Georgia,serif; color: var(--ink-soft); }
 .source-note { margin: 0 clamp(20px,6vw,88px) 90px; padding: 25px; border-top: 1px solid var(--line); color: var(--ink-soft); }
+.editorial-source-note { margin: 0 clamp(20px,6vw,88px) 90px; padding: 25px 0; border-top: 1px solid var(--line); color: var(--ink-soft); }
+.editorial-source-note p:last-child { max-width: 940px; margin-bottom: 0; line-height: 1.65; overflow-wrap: anywhere; }
+.editorial-source-note-compact { margin: 15px 0 0; padding: 15px 0 0; }
+.editorial-source-note-compact .editorial-eyebrow { font-size: 9px; }
+.editorial-source-note-compact p:last-child { margin-top: 7px; font-size: 12px; }
+.editorial-fact-list { margin: 20px 0 0; border-top: 1px solid var(--line); }
+.editorial-fact-list > div { display: grid; grid-template-columns: minmax(90px, .35fr) 1fr; gap: 20px; padding: 11px 0; border-bottom: 1px solid var(--line); font-size: 12px; }
+.editorial-fact-list dt { color: var(--ink-soft); }
+.editorial-fact-list dd { min-width: 0; margin: 0; overflow-wrap: anywhere; }
 .habitat-detail-image { position: relative; min-height: 690px; background: #e4e9df; }
 .habitat-detail-image img { object-fit: cover; }
 .habitat-detail-image > p { position: absolute; bottom: 14px; left: 18px; z-index: 2; font-size: 10px; color: var(--ink-soft); }
@@ -476,7 +525,7 @@ footer div { display: flex; gap: 18px; }
   .hero-media-leaf { right: 0; top: 39%; }
   .hero-media-habitat { left: 24%; bottom: 2%; }
   .section { padding: 80px 16px; }
-  .section-heading { align-items: start; flex-direction: column; }
+  .section-heading, .editorial-section-heading { align-items: start; flex-direction: column; }
   .species-grid, .entity-grid { grid-template-columns: 1fr; }
   .species-image { height: 310px; }
   .relationship-map { margin: 10px; min-height: 0; padding: 30px 20px; }
@@ -498,7 +547,9 @@ footer div { display: flex; gap: 18px; }
   .catalog-toolbar { grid-template-columns: auto 1fr; }
   .catalog-toolbar select { grid-column: 1 / 2; }
   .catalog-toolbar button { grid-column: 2; justify-self: start; }
-  .empty-state { margin: 0 16px 80px; padding: 55px 24px; }
+  .empty-state, .editorial-empty-state { margin: 0 16px 80px; padding: 55px 24px; }
+  .editorial-section-action, .editorial-section-action .editorial-action { width: 100%; }
+  .editorial-fact-list > div { grid-template-columns: 1fr; gap: 5px; }
   .portrait-heading { padding: 48px 25px; }
   .portrait-heading h1 { font-size: 72px; }
   .portrait-nav { justify-content: start; overflow-x: auto; }

--- a/apps/web/src/app/habitat-elements/[slug]/page.tsx
+++ b/apps/web/src/app/habitat-elements/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { ArrowLeft, ArrowRight, Bird, Hammer, MapPin, Ruler, Scissors, Workflow } from "lucide-react";
 import { PublicFooter } from "@/components/public-footer";
 import { SiteHeader } from "@/components/site-header";
+import { EditorialSectionHeading } from "@/components/editorial-primitives";
 import { catalogApi } from "@/lib/catalog/catalog-api";
 
 type PageProps = { params: Promise<{ slug: string }> };
@@ -71,9 +72,7 @@ export default async function HabitatDetailPage({ params }: PageProps) {
           </section>
 
           <section className="related-section">
-            <div className="section-heading">
-              <div><p className="eyebrow">Beziehungen</p><h2>Als Teil eines vernetzten Lebensraums</h2></div>
-            </div>
+            <EditorialSectionHeading eyebrow="Beziehungen" title="Als Teil eines vernetzten Lebensraums" />
             <div className="habitat-relations">
               <div>
                 <p className="eyebrow"><Workflow /> In Kombination mit</p>

--- a/apps/web/src/app/habitat-elements/page.tsx
+++ b/apps/web/src/app/habitat-elements/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { CatalogEntityCard } from "@/components/catalog-entity-card";
 import { CatalogToolbar } from "@/components/catalog-toolbar";
+import { EditorialActionLink, EditorialEmptyState, EditorialEyebrow } from "@/components/editorial-primitives";
 import { PublicFooter } from "@/components/public-footer";
 import { SiteHeader } from "@/components/site-header";
 import { catalogApi } from "@/lib/catalog/catalog-api";
@@ -22,7 +22,7 @@ export default async function HabitatElementsPage({ searchParams }: PageProps) {
       <div className="page-shell">
         <SiteHeader />
         <section className="catalog-intro catalog-intro-habitat">
-          <p className="eyebrow">Planungsbibliothek</p>
+          <EditorialEyebrow>Planungsbibliothek</EditorialEyebrow>
           <h1>Strukturen schaffen.<br /><em>Lebensräume verbinden.</em></h1>
           <p>{habitats.length} Habitatelemente entsprechen der aktuellen Auswahl.</p>
           <CatalogToolbar
@@ -40,11 +40,12 @@ export default async function HabitatElementsPage({ searchParams }: PageProps) {
             ))}
           </section>
         ) : (
-          <section className="empty-state">
-            <p className="eyebrow">Keine Treffer</p>
-            <h2>Kein Habitatelement entspricht dieser Auswahl.</h2>
-            <Link className="outline-link" href="/habitat-elements">Filter zurücksetzen</Link>
-          </section>
+          <EditorialEmptyState
+            title="Kein Habitatelement entspricht dieser Auswahl."
+            action={<EditorialActionLink href="/habitat-elements">Filter zurücksetzen</EditorialActionLink>}
+          >
+            Versuchen Sie einen anderen Suchbegriff oder setzen Sie die Filter zurück.
+          </EditorialEmptyState>
         )}
         <PublicFooter />
       </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, ArrowUpRight, Bird, Building2, Leaf, Search, Sparkles } fro
 import { SiteHeader } from "@/components/site-header";
 import { SpeciesCard } from "@/components/species-card";
 import { PublicFooter } from "@/components/public-footer";
+import { EditorialActionLink, EditorialSectionHeading } from "@/components/editorial-primitives";
 import { catalogApi } from "@/lib/catalog/catalog-api";
 
 export default async function Home() {
@@ -75,13 +76,12 @@ export default async function Home() {
         </section>
 
         <section className="section" aria-labelledby="featured-title">
-          <div className="section-heading">
-            <div>
-              <p className="eyebrow">Arten im Fokus</p>
-              <h2 id="featured-title">Lebensräume aus Sicht der Tiere verstehen</h2>
-            </div>
-            <Link className="outline-link" href="/species">Alle Arten <ArrowRight size={17} /></Link>
-          </div>
+          <EditorialSectionHeading
+            eyebrow="Arten im Fokus"
+            title="Lebensräume aus Sicht der Tiere verstehen"
+            titleId="featured-title"
+            action={<EditorialActionLink href="/species">Alle Arten</EditorialActionLink>}
+          />
           <div className="species-grid">
             {overview.featuredSpecies.map((species, index) => (
               <SpeciesCard key={species.slug} species={species} priority={index === 0} />

--- a/apps/web/src/app/plants/[slug]/page.tsx
+++ b/apps/web/src/app/plants/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { ArrowLeft, ArrowRight, CalendarDays, Leaf, MapPin, Sprout } from "lucide-react";
 import { PublicFooter } from "@/components/public-footer";
 import { SiteHeader } from "@/components/site-header";
+import { EditorialActionLink, EditorialSectionHeading, EditorialSourceNote } from "@/components/editorial-primitives";
 import { catalogApi } from "@/lib/catalog/catalog-api";
 
 type PageProps = { params: Promise<{ slug: string }> };
@@ -83,10 +84,11 @@ export default async function PlantDetailPage({ params }: PageProps) {
           </section>
 
           <section className="related-section">
-            <div className="section-heading">
-              <div><p className="eyebrow">03 · Beziehungen</p><h2>Arten, die von dieser Pflanze profitieren</h2></div>
-              <Link className="outline-link" href="/species">Alle Arten <ArrowRight size={17} /></Link>
-            </div>
+            <EditorialSectionHeading
+              eyebrow="03 · Beziehungen"
+              title="Arten, die von dieser Pflanze profitieren"
+              action={<EditorialActionLink href="/species">Alle Arten</EditorialActionLink>}
+            />
             {plant.relatedSpecies.length ? (
               <div className="related-link-grid">
                 {plant.relatedSpecies.map((species) => (
@@ -99,7 +101,7 @@ export default async function PlantDetailPage({ params }: PageProps) {
               </div>
             ) : <p className="empty-note">Beziehungen folgen mit der vollständigen Datenmigration.</p>}
           </section>
-          <section className="source-note"><p className="eyebrow">Quellen</p><p>{plant.sources.join(" · ")}</p></section>
+          <EditorialSourceNote sources={plant.sources.join(" · ")} />
         </article>
         <PublicFooter />
       </div>

--- a/apps/web/src/app/plants/page.tsx
+++ b/apps/web/src/app/plants/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { CatalogEntityCard } from "@/components/catalog-entity-card";
 import { CatalogToolbar } from "@/components/catalog-toolbar";
+import { EditorialActionLink, EditorialEmptyState, EditorialEyebrow } from "@/components/editorial-primitives";
 import { PublicFooter } from "@/components/public-footer";
 import { SiteHeader } from "@/components/site-header";
 import { catalogApi } from "@/lib/catalog/catalog-api";
@@ -22,7 +22,7 @@ export default async function PlantsPage({ searchParams }: PageProps) {
       <div className="page-shell">
         <SiteHeader />
         <section className="catalog-intro catalog-intro-plant">
-          <p className="eyebrow">Pflanzenbibliothek</p>
+          <EditorialEyebrow>Pflanzenbibliothek</EditorialEyebrow>
           <h1>Pflanzen wählen.<br /><em>Wirkung entfalten.</em></h1>
           <p>{plants.length} Pflanzen entsprechen der aktuellen Auswahl.</p>
           <CatalogToolbar
@@ -38,11 +38,12 @@ export default async function PlantsPage({ searchParams }: PageProps) {
             {plants.map((plant) => <CatalogEntityCard key={plant.slug} kind="plant" item={plant} />)}
           </section>
         ) : (
-          <section className="empty-state">
-            <p className="eyebrow">Keine Treffer</p>
-            <h2>Keine Pflanze entspricht dieser Auswahl.</h2>
-            <Link className="outline-link" href="/plants">Filter zurücksetzen</Link>
-          </section>
+          <EditorialEmptyState
+            title="Keine Pflanze entspricht dieser Auswahl."
+            action={<EditorialActionLink href="/plants">Filter zurücksetzen</EditorialActionLink>}
+          >
+            Versuchen Sie einen anderen Suchbegriff oder setzen Sie die Filter zurück.
+          </EditorialEmptyState>
         )}
         <PublicFooter />
       </div>

--- a/apps/web/src/app/species/[slug]/page.tsx
+++ b/apps/web/src/app/species/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { ArrowLeft, ArrowRight, Bird, Leaf, MapPin, Quote, Sprout } from "lucide-react";
 import { SiteHeader } from "@/components/site-header";
 import { PublicFooter } from "@/components/public-footer";
+import { EditorialEyebrow, EditorialFactList, EditorialSourceNote } from "@/components/editorial-primitives";
 import { catalogApi } from "@/lib/catalog/catalog-api";
 
 type PageProps = { params: Promise<{ slug: string }> };
@@ -65,16 +66,19 @@ export default async function SpeciesDetailPage({ params }: PageProps) {
                 <span>{species.taxonomy.orderCommon}</span>
                 <span>{species.taxonomy.familyCommon}</span>
               </div>
-              <p className="eyebrow">Artenportrait</p>
+              <EditorialEyebrow>Artenportrait</EditorialEyebrow>
               <h1>{species.commonName}</h1>
               <p className="portrait-scientific">{species.scientificName}</p>
               {species.alternativeName && <p className="alternative">Auch bekannt als {species.alternativeName}</p>}
               <p className="portrait-teaser">{species.teaser}</p>
-              <dl className="taxonomy-list">
-                <div><dt>Klasse</dt><dd>{species.taxonomy.classCommon} <i>{species.taxonomy.classScientific}</i></dd></div>
-                <div><dt>Ordnung</dt><dd>{species.taxonomy.orderCommon} <i>{species.taxonomy.orderScientific}</i></dd></div>
-                <div><dt>Familie</dt><dd>{species.taxonomy.familyCommon} <i>{species.taxonomy.familyScientific}</i></dd></div>
-              </dl>
+              <EditorialFactList
+                className="taxonomy-list"
+                items={[
+                  { label: "Klasse", value: <>{species.taxonomy.classCommon} <i>{species.taxonomy.classScientific}</i></> },
+                  { label: "Ordnung", value: <>{species.taxonomy.orderCommon} <i>{species.taxonomy.orderScientific}</i></> },
+                  { label: "Familie", value: <>{species.taxonomy.familyCommon} <i>{species.taxonomy.familyScientific}</i></> }
+                ]}
+              />
             </div>
           </section>
 
@@ -95,7 +99,7 @@ export default async function SpeciesDetailPage({ params }: PageProps) {
                   <p>{attribute.category}</p>
                   <h3>{attribute.label}</h3>
                   <blockquote><Quote size={18} />{attribute.value}</blockquote>
-                  {attribute.sources && <small>{attribute.sources}</small>}
+                  {attribute.sources && <EditorialSourceNote sources={attribute.sources} compact />}
                 </div>
               ))}
             </div>

--- a/apps/web/src/app/species/page.tsx
+++ b/apps/web/src/app/species/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { CatalogToolbar } from "@/components/catalog-toolbar";
+import { EditorialActionLink, EditorialEmptyState, EditorialEyebrow } from "@/components/editorial-primitives";
 import { PublicFooter } from "@/components/public-footer";
 import { SiteHeader } from "@/components/site-header";
 import { SpeciesCard } from "@/components/species-card";
@@ -22,7 +22,7 @@ export default async function SpeciesPage({ searchParams }: PageProps) {
       <div className="page-shell">
         <SiteHeader />
         <section className="catalog-intro">
-          <p className="eyebrow">Artenbibliothek</p>
+          <EditorialEyebrow>Artenbibliothek</EditorialEyebrow>
           <h1>Arten entdecken.<br /><em>Bedürfnisse verstehen.</em></h1>
           <p>{species.length} Artenportraits entsprechen der aktuellen Auswahl.</p>
           <CatalogToolbar
@@ -38,11 +38,12 @@ export default async function SpeciesPage({ searchParams }: PageProps) {
             {species.map((item, index) => <SpeciesCard key={item.slug} species={item} priority={index === 0} />)}
           </section>
         ) : (
-          <section className="empty-state">
-            <p className="eyebrow">Keine Treffer</p>
-            <h2>Keine Art entspricht dieser Auswahl.</h2>
-            <Link className="outline-link" href="/species">Filter zurücksetzen</Link>
-          </section>
+          <EditorialEmptyState
+            title="Keine Art entspricht dieser Auswahl."
+            action={<EditorialActionLink href="/species">Filter zurücksetzen</EditorialActionLink>}
+          >
+            Versuchen Sie einen anderen Suchbegriff oder setzen Sie die Filter zurück.
+          </EditorialEmptyState>
         )}
         <PublicFooter />
       </div>

--- a/apps/web/src/components/catalog-entity-card.tsx
+++ b/apps/web/src/components/catalog-entity-card.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowRight, Building2, Leaf } from "lucide-react";
+import { Building2, Leaf } from "lucide-react";
+import { EditorialActionLink, EditorialEyebrow } from "@/components/editorial-primitives";
 import type { HabitatSummary, PlantSummary } from "@/lib/catalog/types";
 
 type PlantCardProps = { kind: "plant"; item: PlantSummary };
@@ -33,13 +34,11 @@ export function CatalogEntityCard(props: PlantCardProps | HabitatCardProps) {
         <span>{isPlant ? <Leaf size={14} /> : <Building2 size={14} />}{label}</span>
       </Link>
       <div className="entity-card-content">
-        <p className="eyebrow">{props.kind === "plant" ? props.item.floweringPeriod ?? "Pflanzenart" : props.item.location ?? "Planungsbaustein"}</p>
+        <EditorialEyebrow>{props.kind === "plant" ? props.item.floweringPeriod ?? "Pflanzenart" : props.item.location ?? "Planungsbaustein"}</EditorialEyebrow>
         <h2><Link href={href}>{title}</Link></h2>
         {props.kind === "plant" && <p className="scientific">{props.item.scientificName}</p>}
         <p>{props.item.teaser}</p>
-        <Link className="text-link" href={href}>
-          Details öffnen <ArrowRight size={17} />
-        </Link>
+        <EditorialActionLink variant="text" href={href}>Details öffnen</EditorialActionLink>
       </div>
     </article>
   );

--- a/apps/web/src/components/editorial-primitives.test.tsx
+++ b/apps/web/src/components/editorial-primitives.test.tsx
@@ -1,0 +1,53 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  EditorialActionLink,
+  EditorialEmptyState,
+  EditorialFactList,
+  EditorialSectionHeading,
+  EditorialSourceNote
+} from "./editorial-primitives";
+
+describe("editorial primitives", () => {
+  it("connects a section heading to its title and action", () => {
+    const html = renderToStaticMarkup(
+      <section aria-labelledby="species-title">
+        <EditorialSectionHeading
+          eyebrow="Arten im Fokus"
+          title="Lebensräume verstehen"
+          titleId="species-title"
+          action={<EditorialActionLink href="/species">Alle Arten</EditorialActionLink>}
+        />
+      </section>
+    );
+
+    expect(html).toContain('aria-labelledby="species-title"');
+    expect(html).toContain('<h2 id="species-title">Lebensräume verstehen</h2>');
+    expect(html).toContain('href="/species"');
+  });
+
+  it("renders facts and sources with semantic description markup", () => {
+    const html = renderToStaticMarkup(
+      <>
+        <EditorialFactList items={[{ label: "Klasse", value: "Vögel" }]} />
+        <EditorialSourceNote sources="Beispielquelle" />
+      </>
+    );
+
+    expect(html).toContain("<dl");
+    expect(html).toContain("<dt>Klasse</dt>");
+    expect(html).toContain('aria-label="Quellen"');
+  });
+
+  it("announces empty catalogue results without coupling them to one entity", () => {
+    const html = renderToStaticMarkup(
+      <EditorialEmptyState
+        title="Keine Ergebnisse"
+        action={<EditorialActionLink href="/species">Filter zurücksetzen</EditorialActionLink>}
+      />
+    );
+
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain("Keine Ergebnisse");
+  });
+});

--- a/apps/web/src/components/editorial-primitives.tsx
+++ b/apps/web/src/components/editorial-primitives.tsx
@@ -1,0 +1,106 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+function classes(...values: Array<string | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+export function EditorialEyebrow({ children, className }: { children: ReactNode; className?: string }) {
+  return <p className={classes("editorial-eyebrow", className)}>{children}</p>;
+}
+
+export function EditorialActionLink({
+  href,
+  children,
+  variant = "outline",
+  className
+}: {
+  href: string;
+  children: ReactNode;
+  variant?: "primary" | "outline" | "text";
+  className?: string;
+}) {
+  return (
+    <Link className={classes("editorial-action", `editorial-action-${variant}`, className)} href={href}>
+      <span>{children}</span>
+      <ArrowRight aria-hidden="true" size={17} />
+    </Link>
+  );
+}
+
+export function EditorialSectionHeading({
+  eyebrow,
+  title,
+  titleId,
+  lede,
+  action,
+  className
+}: {
+  eyebrow: ReactNode;
+  title: ReactNode;
+  titleId?: string;
+  lede?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <header className={classes("editorial-section-heading", className)}>
+      <div>
+        <EditorialEyebrow>{eyebrow}</EditorialEyebrow>
+        <h2 id={titleId}>{title}</h2>
+        {lede && <p className="editorial-lede">{lede}</p>}
+      </div>
+      {action && <div className="editorial-section-action">{action}</div>}
+    </header>
+  );
+}
+
+export function EditorialEmptyState({
+  title,
+  children,
+  action,
+  className
+}: {
+  title: ReactNode;
+  children?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={classes("editorial-empty-state", className)} aria-live="polite">
+      <EditorialEyebrow>Keine Treffer</EditorialEyebrow>
+      <h2>{title}</h2>
+      {children && <p>{children}</p>}
+      {action && <div className="editorial-empty-action">{action}</div>}
+    </section>
+  );
+}
+
+export function EditorialSourceNote({ sources, compact = false }: { sources: ReactNode; compact?: boolean }) {
+  return (
+    <aside className={classes("editorial-source-note", compact ? "editorial-source-note-compact" : undefined)} aria-label="Quellen">
+      <EditorialEyebrow>Quellen</EditorialEyebrow>
+      <p>{sources}</p>
+    </aside>
+  );
+}
+
+export function EditorialFactList({
+  items,
+  className
+}: {
+  items: Array<{ label: ReactNode; value: ReactNode }>;
+  className?: string;
+}) {
+  return (
+    <dl className={classes("editorial-fact-list", className)}>
+      {items.map((item) => (
+        <div key={String(item.label)}>
+          <dt>{item.label}</dt>
+          <dd>{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/apps/web/src/components/species-card.tsx
+++ b/apps/web/src/components/species-card.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { EditorialActionLink, EditorialEyebrow } from "@/components/editorial-primitives";
 import type { SpeciesSummary } from "@/lib/catalog/types";
 
 export function SpeciesCard({ species, priority = false }: { species: SpeciesSummary; priority?: boolean }) {
@@ -17,15 +17,15 @@ export function SpeciesCard({ species, priority = false }: { species: SpeciesSum
         <span>{species.className}</span>
       </Link>
       <div className="species-card-content">
-        <p className="eyebrow">{species.familyName}</p>
+        <EditorialEyebrow>{species.familyName}</EditorialEyebrow>
         <h3>
           <Link href={`/species/${species.slug}`}>{species.commonName}</Link>
         </h3>
         <p className="scientific">{species.scientificName}</p>
         <p>{species.teaser}</p>
-        <Link className="text-link" href={`/species/${species.slug}`}>
-          Artenportrait öffnen <ArrowRight size={17} />
-        </Link>
+        <EditorialActionLink variant="text" href={`/species/${species.slug}`}>
+          Artenportrait öffnen
+        </EditorialActionLink>
       </div>
     </article>
   );

--- a/docs/replacement-app/editorial-system.md
+++ b/docs/replacement-app/editorial-system.md
@@ -1,0 +1,36 @@
+# Editorial UI system
+
+The public application uses one small editorial system rather than page-specific visual patterns. Management screens remain deliberately separate under the `.management` namespace.
+
+## Foundations
+
+- **Colour:** semantic CSS tokens distinguish text, muted text, brand surfaces, accent, borders and focus. Components must use tokens instead of introducing one-off hex colours.
+- **Type:** `--font-editorial` is used for expressive headings and scientific names; `--font-interface` is used for navigation, labels, controls and body copy.
+- **Space and shape:** `--space-*`, `--radius-*`, `--shadow-*` and `--content-*` tokens provide the shared rhythm. Public cards and sections use the same corner and border language.
+- **Motion:** motion supports orientation and reveal only. Every animation has a `prefers-reduced-motion` fallback.
+- **Focus:** all keyboard-operable elements receive a visible orange focus ring. Search and filter groups also expose `:focus-within` state.
+
+## Reusable primitives
+
+`src/components/editorial-primitives.tsx` contains the public building blocks:
+
+- `EditorialEyebrow` for short navigational labels;
+- `EditorialSectionHeading` for section hierarchy, optional explanatory copy and an action;
+- `EditorialActionLink` with primary, outline and text variants;
+- `EditorialEmptyState` for filtered, sparse or unavailable collections;
+- `EditorialFactList` for label/value facts using semantic description-list markup;
+- `EditorialSourceNote` for attribution and literature notes.
+
+Prefer these primitives whenever a pattern appears on more than one route. Entity-specific components may compose them, but should not reproduce their typography, focus or spacing rules.
+
+## Content and responsive rules
+
+- German labels may wrap; headings and buttons must not rely on fixed text widths.
+- Missing images use an intentional entity illustration or neutral surface, never an empty broken frame.
+- Missing relationships use a neutral empty state and must not mention mock data or migration internals.
+- At narrow widths, section actions move below their headings and catalogue cards become a single column.
+- The supported narrow reference width is 390 px. Touch targets remain at least 44 px where the component is an important action.
+
+## Boundary with management UI
+
+Public primitives use the `editorial-*` namespace. Management components use the existing `management-*` namespace and may share low-level colour tokens only. Editorial typography, cards and motion must not leak into authenticated work screens.


### PR DESCRIPTION
Closes #87

## Outcome
- introduces semantic public design tokens and reusable editorial primitives
- migrates shared headings, actions, catalogue empty states, facts, and source notes across public routes
- adds visible keyboard focus, responsive behavior, reduced-motion support, and a documented boundary from management UI
- preserves both PostgreSQL-backed rendering and the explicit development mock mode

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm test` (7 tests)
- `DATABASE_URL=... CATALOG_DATA_SOURCE=postgres npx next build --webpack` (345 generated pages)
- visual checks at 390 px, 768 px, and desktop; no horizontal overflow
- mock mode: landing page and `/species/gimpel` rendered successfully

## Notes
The default Turbopack production build cannot bind its internal helper port in the current sandbox, so the production verification used the supported webpack builder. This is an environment restriction, not an application failure.

User-owned changes in `.gitignore`, `README.md`, and `docs/replacement-app/implementation-plan.md` were intentionally left out.