### PR TITLE
Canonical public entry points and editorial species browsers

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -165,9 +165,12 @@ h1 em, h2 em { color: var(--orange); font-weight: 400; }
 .species-image:hover img { transform: scale(1.035); }
 .species-image > span { position: absolute; left: 18px; top: 18px; z-index: 2; background: rgba(255,253,248,.9); padding: 7px 11px; border-radius: 999px; font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; }
 .species-card-content { padding: 28px; }
-.species-card h3 { font-family: Georgia, serif; font-size: 33px; font-weight: 400; margin: 6px 0 0; }
+.species-card :is(h2, h3) { font-family: Georgia, serif; font-size: 33px; font-weight: 400; margin: 6px 0 0; }
 .scientific, .portrait-scientific { font-family: Georgia, serif; font-style: italic; color: var(--ink-soft); }
-.species-card-content > p:not(.eyebrow):not(.editorial-eyebrow):not(.scientific) { color: var(--ink-soft); line-height: 1.55; min-height: 72px; }
+.species-card-content > p:not(.eyebrow):not(.editorial-eyebrow):not(.scientific) {
+  display: -webkit-box; min-height: 72px; overflow: hidden; color: var(--ink-soft); line-height: 1.55;
+  -webkit-box-orient: vertical; -webkit-line-clamp: 3;
+}
 .text-link { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 800; margin-top: 12px; color: var(--forest); }
 .relationship-section { display: grid; grid-template-columns: minmax(0, .82fr) minmax(0, 1.18fr); min-height: 600px; background: #dcead4; border-radius: 24px; overflow: hidden; }
 .relationship-copy { padding: clamp(55px, 7vw, 100px); display: flex; flex-direction: column; justify-content: center; }
@@ -236,6 +239,23 @@ a.flow-card:hover { transform: translateY(-3px); background: rgba(255,255,255,.1
   display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(320px, .85fr); gap: 70px;
   margin-top: 16px; padding: clamp(64px, 7vw, 104px); border-radius: 24px;
   background: #dcead4; border: 1px solid rgba(23,53,46,.08);
+}
+.catalog-preview-section {
+  margin: 16px 0; padding: 110px clamp(20px, 6vw, 88px); border-radius: var(--radius-section);
+  background: var(--paper); border: 1px solid rgba(23,53,46,.08);
+}
+.catalog-preview-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+.catalog-preview-group { min-width: 0; padding-top: 22px; border-top: 1px solid var(--line); }
+.catalog-preview-group > header { display: flex; justify-content: space-between; align-items: center; gap: 20px; margin-bottom: 20px; }
+.catalog-preview-group > header > div { display: flex; align-items: center; gap: 10px; }
+.catalog-preview-group > header svg { color: var(--orange); }
+.catalog-preview-group h3 { margin: 0; font: 400 27px/1.1 var(--font-editorial); }
+.catalog-preview-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.catalog-preview-cards .entity-visual { height: 220px; }
+.catalog-preview-cards .entity-card-content { padding: 22px; }
+.catalog-preview-cards .entity-card-content h4 { margin: 7px 0; font: 400 27px/1.05 var(--font-editorial); }
+.catalog-preview-cards .entity-card-content > p:not(.eyebrow):not(.editorial-eyebrow):not(.scientific) {
+  display: -webkit-box; min-height: 0; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 3;
 }
 .project-context-copy h2 {
   max-width: 760px; margin: 12px 0 28px;
@@ -352,9 +372,14 @@ footer div { display: flex; gap: 18px; }
 .botanical-mark svg { width: 92px; height: 92px; color: var(--forest); stroke-width: 1.1; z-index: 2; }
 .botanical-mark i { position: absolute; width: 260px; height: 260px; border: 1px solid rgba(19,79,64,.22); border-radius: 50%; }
 .botanical-mark i:last-child { width: 160px; height: 160px; background: rgba(220,237,144,.55); border: 0; }
+.botanical-mark-habitat { background: linear-gradient(145deg, #e9e3d5, #cdd9c7); }
+.botanical-mark-habitat i:last-child { background: rgba(224,108,61,.16); }
 .entity-card-content { padding: 28px; }
-.entity-card-content h2 { font: 400 33px/1.05 Georgia,serif; margin: 7px 0; }
-.entity-card-content > p:not(.eyebrow):not(.editorial-eyebrow):not(.scientific) { color: var(--ink-soft); line-height: 1.55; min-height: 72px; }
+.entity-card-content :is(h2, h3, h4) { font: 400 33px/1.05 Georgia,serif; margin: 7px 0; }
+.entity-card-content > p:not(.eyebrow):not(.editorial-eyebrow):not(.scientific) {
+  display: -webkit-box; min-height: 72px; overflow: hidden; color: var(--ink-soft); line-height: 1.55;
+  -webkit-box-orient: vertical; -webkit-line-clamp: 3;
+}
 .entity-detail-hero { display: grid; grid-template-columns: 1fr 1fr; min-height: 690px; overflow: hidden; border-radius: 24px; background: var(--paper); }
 .entity-detail-heading { padding: clamp(50px,7vw,96px); display: flex; flex-direction: column; justify-content: center; }
 .entity-detail-heading h1 { font: 400 clamp(64px,7vw,108px)/.92 Georgia,serif; letter-spacing: -.05em; margin: 10px 0; }
@@ -489,6 +514,7 @@ footer div { display: flex; gap: 18px; }
   .species-grid, .entity-grid { grid-template-columns: 1fr 1fr; }
   .relationship-section, .portrait-section, .planning-section, .lifecycle-section, .entity-story, .site-condition-band { grid-template-columns: 1fr; }
   .project-context { grid-template-columns: 1fr; gap: 38px; }
+  .catalog-preview-columns { grid-template-columns: 1fr; gap: 48px; }
   .project-partners { grid-column: auto; align-items: flex-start; flex-direction: column; }
   .partner-logos { justify-content: flex-start; flex-wrap: wrap; }
   .portrait-image { min-height: 550px; }
@@ -525,6 +551,9 @@ footer div { display: flex; gap: 18px; }
   .hero-media-leaf { right: 0; top: 39%; }
   .hero-media-habitat { left: 24%; bottom: 2%; }
   .section { padding: 80px 16px; }
+  .catalog-preview-section { padding: 75px 16px; }
+  .catalog-preview-cards { grid-template-columns: 1fr; }
+  .catalog-preview-group > header { align-items: flex-start; flex-direction: column; }
   .section-heading, .editorial-section-heading { align-items: start; flex-direction: column; }
   .species-grid, .entity-grid { grid-template-columns: 1fr; }
   .species-image { height: 310px; }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -335,11 +335,36 @@ footer div { display: flex; gap: 18px; }
 .portrait-nav a { padding: 10px 15px; border-radius: 999px; font-size: 12px; font-weight: 700; }
 .portrait-nav a:hover { background: var(--mint); }
 .portrait-section, .planning-section { display: grid; grid-template-columns: .72fr 1.28fr; gap: 70px; padding: 120px clamp(20px, 6vw, 88px); }
-.attribute-item { padding: 34px 0; border-top: 1px solid #bbc8c0; }
-.attribute-item > p { color: var(--orange); text-transform: uppercase; letter-spacing: .12em; font-size: 10px; font-weight: 800; }
-.attribute-item h3 { font-family: Georgia, serif; font-size: 29px; font-weight: 400; margin: 10px 0; }
+.attribute-browser { display: grid; grid-template-columns: minmax(155px, .34fr) minmax(0, 1fr); gap: clamp(28px, 4vw, 56px); align-items: start; }
+.attribute-index { position: sticky; top: 92px; align-self: start; }
+.attribute-index > p { margin: 0 0 11px; color: var(--orange); font-size: 9px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+.attribute-index ol { display: grid; gap: 2px; margin: 0; padding: 0; list-style: none; }
+.attribute-index a { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; align-items: start; padding: 10px 8px 10px 12px; border-left: 2px solid transparent; color: var(--ink-soft); font-size: 12px; line-height: 1.35; transition: border-color .18s ease, color .18s ease, background .18s ease; }
+.attribute-index a:hover { color: var(--ink); background: rgba(188,232,212,.25); }
+.attribute-index a[aria-current="location"] { border-left-color: var(--orange); color: var(--ink); background: rgba(188,232,212,.38); font-weight: 700; }
+.attribute-index small { color: #71837d; font-size: 10px; font-variant-numeric: tabular-nums; }
+.attribute-categories { min-width: 0; }
+.attribute-category { scroll-margin-top: 104px; padding: 0 0 72px; }
+.attribute-category:last-child { padding-bottom: 0; }
+.attribute-category > header { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 5px 18px; align-items: end; margin-bottom: 15px; }
+.attribute-category > header > p { grid-column: 1 / -1; margin: 0; color: var(--orange); font-size: 9px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+.attribute-category > header h3 { margin: 0; font: 400 clamp(25px, 2.4vw, 36px)/1.08 Georgia, serif; }
+.attribute-category > header > span { padding-bottom: 3px; color: #71837d; font-size: 11px; white-space: nowrap; }
+.attribute-group { border-top: 1px solid #bbc8c0; }
+.attribute-group:last-child { border-bottom: 1px solid #bbc8c0; }
+.attribute-group > summary { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 12px; align-items: center; padding: 18px 2px; cursor: pointer; list-style: none; }
+.attribute-group > summary::-webkit-details-marker { display: none; }
+.attribute-group > summary svg { color: var(--orange); transition: transform .18s ease; }
+.attribute-group[open] > summary svg { transform: rotate(90deg); }
+.attribute-group > summary > span { font: 400 clamp(18px, 1.7vw, 23px)/1.2 Georgia, serif; }
+.attribute-group > summary small { color: #71837d; font-size: 10px; white-space: nowrap; }
+.attribute-group-content { padding: 0 0 8px 30px; }
+.attribute-item { padding: 24px 0; border-top: 1px solid rgba(187,200,192,.62); }
+.attribute-item:first-child { border-top: 0; }
+.attribute-item h4 { font-family: Georgia, serif; font-size: 22px; font-weight: 400; margin: 0 0 10px; }
 .attribute-item blockquote { margin: 0; font-size: 17px; line-height: 1.7; color: var(--ink-soft); display: grid; grid-template-columns: auto 1fr; gap: 10px; }
 .attribute-item blockquote svg { color: #91a99e; margin-top: 5px; }
+.attribute-item blockquote span { min-width: 0; overflow-wrap: anywhere; }
 .attribute-item small { display: block; margin-top: 15px; color: #71837d; }
 .lifecycle-section { display: grid; grid-template-columns: .7fr 1.3fr; gap: 70px; align-items: center; padding: 90px clamp(20px, 6vw, 88px); background: var(--forest); color: white; border-radius: 24px; }
 .lifecycle-section > div:first-child > p:not(.eyebrow) { line-height: 1.65; opacity: .7; }
@@ -513,6 +538,7 @@ footer div { display: flex; gap: 18px; }
   .hero-art { min-height: 620px; width: 100%; transform: none; }
   .species-grid, .entity-grid { grid-template-columns: 1fr 1fr; }
   .relationship-section, .portrait-section, .planning-section, .lifecycle-section, .entity-story, .site-condition-band { grid-template-columns: 1fr; }
+  .attribute-browser { grid-template-columns: minmax(150px, .3fr) minmax(0, 1fr); }
   .project-context { grid-template-columns: 1fr; gap: 38px; }
   .catalog-preview-columns { grid-template-columns: 1fr; gap: 48px; }
   .project-partners { grid-column: auto; align-items: flex-start; flex-direction: column; }
@@ -583,6 +609,13 @@ footer div { display: flex; gap: 18px; }
   .portrait-heading h1 { font-size: 72px; }
   .portrait-nav { justify-content: start; overflow-x: auto; }
   .portrait-section, .planning-section, .lifecycle-section { padding: 80px 22px; gap: 40px; }
+  .attribute-browser { grid-template-columns: 1fr; gap: 34px; }
+  .attribute-index { position: static; }
+  .attribute-index ol { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 5px; }
+  .attribute-index a { min-height: 100%; border: 1px solid var(--line); border-radius: 12px; padding: 11px; background: rgba(255,253,248,.45); }
+  .attribute-index a[aria-current="location"] { border-color: var(--orange); background: rgba(188,232,212,.38); }
+  .attribute-category { scroll-margin-top: 90px; padding-bottom: 58px; }
+  .attribute-group-content { padding-left: 26px; }
   .lifecycle-image { min-height: 330px; }
   .planning-columns { grid-template-columns: 1fr; }
   .entity-detail-heading { padding: 48px 25px; }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -383,16 +383,46 @@ footer div { display: flex; gap: 18px; }
 .lifecycle-image { position: relative; min-height: 540px; border-radius: 50%; background: white; overflow: hidden; }
 .lifecycle-image img { object-fit: contain; }
 .planning-section { grid-template-columns: .7fr 1.3fr; }
-.planning-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
-.planning-columns > div { background: var(--paper); border-radius: 18px; padding: 26px; }
-.planning-heading { display: flex; gap: 12px; align-items: center; padding-bottom: 20px; border-bottom: 1px solid var(--line); }
-.planning-heading > span { display: grid; font-family: Georgia, serif; font-size: 23px; }
-.planning-heading small { font: 800 9px Arial, sans-serif; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-soft); }
-.relation-row { display: grid; grid-template-columns: auto 1fr auto; gap: 10px; align-items: center; padding: 17px 0; border-bottom: 1px solid var(--line); }
-.relation-row div { display: grid; gap: 3px; }
-.relation-row strong { font-size: 13px; }
-.relation-row i { color: var(--ink-soft); font: italic 12px Georgia, serif; }
-.relation-row > span { max-width: 110px; text-align: right; color: var(--ink-soft); font-size: 10px; }
+.planning-browser { min-width: 0; overflow: hidden; background: var(--paper); border-radius: 18px; }
+.planning-browser-toolbar { display: grid; grid-template-columns: minmax(220px, 1fr) auto; gap: 13px 18px; padding: 24px 26px 20px; border-bottom: 1px solid var(--line); }
+.planning-search { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 9px; padding: 10px 13px; border: 1px solid var(--line); border-radius: 999px; background: #fbfcfa; color: var(--ink-soft); }
+.planning-search:focus-within { border-color: #7c9c8e; box-shadow: 0 0 0 3px rgba(188,232,212,.35); }
+.planning-search input { min-width: 0; border: 0; outline: 0; background: transparent; color: var(--ink); font-size: 12px; }
+.planning-filter-group { display: flex; flex-wrap: wrap; gap: 5px; }
+.planning-filter-type { grid-column: 1; }
+.planning-filter-stage { grid-column: 2; justify-content: end; }
+.planning-filter-group button { padding: 8px 11px; border: 1px solid var(--line); border-radius: 999px; background: transparent; color: var(--ink-soft); cursor: pointer; font-size: 10px; font-weight: 700; transition: color .18s ease, border-color .18s ease, background .18s ease; }
+.planning-filter-group button:hover { color: var(--ink); border-color: #8fa79b; }
+.planning-filter-group button[aria-pressed="true"] { color: var(--forest); border-color: transparent; background: var(--mint); }
+.planning-result-summary { grid-column: 1 / -1; display: flex; align-items: center; gap: 5px; padding-top: 12px; border-top: 1px solid rgba(187,200,192,.65); color: var(--ink-soft); font-size: 11px; }
+.planning-result-summary strong { color: var(--ink); font-size: 13px; font-variant-numeric: tabular-nums; }
+.planning-result-summary button { display: inline-flex; align-items: center; gap: 5px; margin-left: auto; padding: 0; border: 0; background: transparent; color: var(--ink-soft); cursor: pointer; font-size: 10px; font-weight: 700; }
+.planning-result-summary button:hover { color: var(--ink); }
+.planning-function-groups { padding: 0 26px 12px; }
+.planning-function-group { border-bottom: 1px solid #bbc8c0; }
+.planning-function-group > summary { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 12px; align-items: center; padding: 21px 1px; cursor: pointer; list-style: none; }
+.planning-function-group > summary::-webkit-details-marker { display: none; }
+.planning-function-group > summary > svg { color: var(--orange); transition: transform .18s ease; }
+.planning-function-group[open] > summary > svg { transform: rotate(90deg); }
+.planning-function-group > summary > span { display: grid; gap: 3px; min-width: 0; }
+.planning-function-group > summary strong { font: 400 clamp(20px, 1.8vw, 27px)/1.1 Georgia, serif; }
+.planning-function-group > summary small { color: var(--ink-soft); font-size: 10px; }
+.planning-function-group > summary > em { color: #71837d; font-size: 10px; font-style: normal; white-space: nowrap; }
+.planning-function-content { padding: 0 0 22px 32px; }
+.planning-relation-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); column-gap: 26px; }
+.planning-relation { display: grid; grid-template-columns: auto minmax(105px, 1fr) minmax(80px, .8fr); gap: 10px; align-items: center; min-width: 0; padding: 15px 0; border-top: 1px solid rgba(187,200,192,.62); }
+.planning-relation:hover strong { color: #316d55; }
+.planning-relation > svg { width: 17px; color: var(--forest); }
+.planning-relation > span { display: grid; gap: 3px; min-width: 0; }
+.planning-relation strong { font-size: 12px; transition: color .18s ease; overflow-wrap: anywhere; }
+.planning-relation i { color: var(--ink-soft); font: italic 11px Georgia, serif; overflow-wrap: anywhere; }
+.planning-relation > small { display: grid; gap: 3px; color: var(--ink-soft); font-size: 9px; line-height: 1.35; text-align: right; overflow-wrap: anywhere; }
+.planning-relation > small em { color: #71837d; font-style: normal; }
+.planning-reveal { display: block; margin: 17px auto 0; padding: 10px 15px; border: 1px solid var(--forest); border-radius: 999px; background: transparent; color: var(--forest); cursor: pointer; font-size: 10px; font-weight: 800; }
+.planning-reveal:hover { background: var(--mint); }
+.planning-empty { margin: 0 26px 26px; padding: 30px; border-radius: 14px; background: #eef3eb; text-align: center; }
+.planning-empty p { color: var(--ink-soft); }
+.planning-empty button { padding: 10px 14px; border: 1px solid var(--forest); border-radius: 999px; background: transparent; color: var(--forest); cursor: pointer; font-size: 10px; font-weight: 800; }
 .empty-note { color: var(--ink-soft); font-size: 13px; padding: 18px 0; }
 .portrait-cta { display: flex; justify-content: space-between; align-items: end; gap: 30px; padding: 70px clamp(20px, 6vw, 88px); background: var(--lime); border-radius: 24px; }
 .portrait-cta h2 { font: 400 clamp(34px, 4vw, 58px)/1.05 Georgia, serif; margin: 10px 0 0; max-width: 760px; }
@@ -631,7 +661,14 @@ footer div { display: flex; gap: 18px; }
   .attribute-category { scroll-margin-top: 90px; padding-bottom: 58px; }
   .attribute-group-content { padding-left: 26px; }
   .lifecycle-image { min-height: 330px; }
-  .planning-columns { grid-template-columns: 1fr; }
+  .planning-browser-toolbar { grid-template-columns: 1fr; padding: 20px; }
+  .planning-filter-type, .planning-filter-stage { grid-column: 1; justify-content: start; }
+  .planning-function-groups { padding: 0 20px 10px; }
+  .planning-function-group > summary { grid-template-columns: auto minmax(0, 1fr); }
+  .planning-function-group > summary > em { grid-column: 2; }
+  .planning-function-content { padding-left: 29px; }
+  .planning-relation-grid { grid-template-columns: 1fr; }
+  .planning-empty { margin: 0 20px 20px; }
   .entity-detail-heading { padding: 48px 25px; }
   .entity-detail-heading h1 { font-size: 58px; }
   .plant-hero-art, .habitat-detail-image { min-height: 410px; }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -331,9 +331,20 @@ footer div { display: flex; gap: 18px; }
 .taxonomy-list dt { color: var(--ink-soft); }
 .taxonomy-list dd { margin: 0; }
 .taxonomy-list i { color: var(--ink-soft); margin-left: 4px; }
-.portrait-nav { position: sticky; top: 12px; z-index: 10; display: flex; justify-content: center; gap: 10px; margin: 18px auto; width: fit-content; max-width: 90%; padding: 7px; background: rgba(255,253,248,.92); backdrop-filter: blur(12px); border: 1px solid var(--line); border-radius: 999px; }
-.portrait-nav a { padding: 10px 15px; border-radius: 999px; font-size: 12px; font-weight: 700; }
-.portrait-nav a:hover { background: var(--mint); }
+.portrait-nav-sentinel { display: block; height: 1px; margin-bottom: -1px; }
+.portrait-nav { position: sticky; top: 12px; z-index: 10; display: flex; align-items: center; justify-content: center; gap: 0; margin: 18px auto; width: fit-content; max-width: calc(100% - 24px); padding: 7px; background: rgba(255,253,248,.92); backdrop-filter: blur(12px); border: 1px solid var(--line); border-radius: 999px; box-shadow: 0 8px 30px rgba(23,53,46,.04); transition: width .22s ease, box-shadow .22s ease; }
+.portrait-nav.is-stuck { width: min(920px, calc(100% - 24px)); justify-content: space-between; box-shadow: var(--shadow-floating); }
+.portrait-nav-identity { display: flex; align-items: center; gap: 10px; max-width: 0; padding: 0; overflow: hidden; opacity: 0; visibility: hidden; transform: translateX(-6px); transition: max-width .22s ease, padding .22s ease, opacity .16s ease, transform .22s ease; }
+.portrait-nav.is-stuck .portrait-nav-identity { max-width: 260px; padding: 0 18px 0 0; opacity: 1; visibility: visible; transform: translateX(0); }
+.portrait-nav-thumbnail { width: 42px; height: 42px; flex: 0 0 42px; overflow: hidden; border-radius: 50%; background: #dce8df; }
+.portrait-nav-thumbnail img { width: 100%; height: 100%; object-fit: cover; }
+.portrait-nav-names { display: grid; gap: 2px; min-width: 0; white-space: nowrap; }
+.portrait-nav-names strong { font-size: 12px; }
+.portrait-nav-names i { color: var(--ink-soft); font: italic 11px Georgia, serif; }
+.portrait-nav-links { display: flex; justify-content: center; gap: 4px; }
+.portrait-nav a { padding: 10px 15px; border-radius: 999px; font-size: 12px; font-weight: 700; transition: color .18s ease, background .18s ease; }
+.portrait-nav a:hover { background: rgba(188,232,212,.48); }
+.portrait-nav a[aria-current="location"] { color: var(--forest); background: var(--mint); }
 .portrait-section, .planning-section { display: grid; grid-template-columns: .72fr 1.28fr; gap: 70px; padding: 120px clamp(20px, 6vw, 88px); }
 .attribute-browser { display: grid; grid-template-columns: minmax(155px, .34fr) minmax(0, 1fr); gap: clamp(28px, 4vw, 56px); align-items: start; }
 .attribute-index { position: sticky; top: 92px; align-self: start; }
@@ -544,6 +555,7 @@ footer div { display: flex; gap: 18px; }
   .project-partners { grid-column: auto; align-items: flex-start; flex-direction: column; }
   .partner-logos { justify-content: flex-start; flex-wrap: wrap; }
   .portrait-image { min-height: 550px; }
+  .portrait-nav.is-stuck .portrait-nav-names i { display: none; }
   .plant-hero-art, .habitat-detail-image { min-height: 520px; }
   .metric-grid { grid-template-columns: 1fr 1fr; }
   .editor-grid { grid-template-columns: 1fr; }
@@ -608,6 +620,8 @@ footer div { display: flex; gap: 18px; }
   .portrait-heading { padding: 48px 25px; }
   .portrait-heading h1 { font-size: 72px; }
   .portrait-nav { justify-content: start; overflow-x: auto; }
+  .portrait-nav.is-stuck { width: fit-content; justify-content: start; }
+  .portrait-nav.is-stuck .portrait-nav-identity { display: none; }
   .portrait-section, .planning-section, .lifecycle-section { padding: 80px 22px; gap: 40px; }
   .attribute-browser { grid-template-columns: 1fr; gap: 34px; }
   .attribute-index { position: static; }

--- a/apps/web/src/app/habitat-elements/[slug]/page.tsx
+++ b/apps/web/src/app/habitat-elements/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function HabitatDetailPage({ params }: PageProps) {
                 <p className="eyebrow"><Workflow /> In Kombination mit</p>
                 {habitat.combinedWith.length ? habitat.combinedWith.map((related) => (
                   <Link href={`/habitat-elements/${related.slug}`} key={related.slug}>{related.name}<ArrowRight /></Link>
-                )) : <p className="empty-note">Keine Kombinationen im Mock erfasst.</p>}
+                )) : <p className="empty-note">Für dieses Habitatelement sind derzeit keine Kombinationen hinterlegt.</p>}
               </div>
               <div>
                 <p className="eyebrow"><Bird /> Zielarten</p>
@@ -87,7 +87,7 @@ export default async function HabitatDetailPage({ params }: PageProps) {
                     <span><strong>{species.commonName}</strong><i>{species.scientificName}</i></span>
                     <small>{species.purpose} · {species.lifecycleStage}</small>
                   </Link>
-                )) : <p className="empty-note">Zielart-Beziehungen folgen mit der Datenmigration.</p>}
+                )) : <p className="empty-note">Für dieses Habitatelement sind derzeit keine Zielart-Beziehungen hinterlegt.</p>}
               </div>
             </div>
           </section>

--- a/apps/web/src/app/habitat-elements/page.tsx
+++ b/apps/web/src/app/habitat-elements/page.tsx
@@ -15,7 +15,11 @@ type PageProps = { searchParams: Promise<{ q?: string; type?: string }> };
 
 export default async function HabitatElementsPage({ searchParams }: PageProps) {
   const query = await searchParams;
-  const habitats = (await catalogApi.listHabitats(query)).filter((item) => item.status === "published");
+  const [listedHabitats, catalogTypes] = await Promise.all([
+    catalogApi.listHabitats(query),
+    catalogApi.getCatalogTypes()
+  ]);
+  const habitats = listedHabitats.filter((item) => item.status === "published");
 
   return (
     <main>
@@ -29,7 +33,7 @@ export default async function HabitatElementsPage({ searchParams }: PageProps) {
             action="/habitat-elements"
             query={query.q}
             type={query.type}
-            types={["Vegetation", "Ausstattungselement"]}
+            types={catalogTypes.habitatTypes}
             searchLabel="Nach Element, Typ oder Standort suchen"
           />
         </section>

--- a/apps/web/src/app/imprint/page.tsx
+++ b/apps/web/src/app/imprint/page.tsx
@@ -10,7 +10,7 @@ export default function ImprintPage() {
       <p className="eyebrow">Rechtliches</p><h1>Impressum</h1>
       <p>Die verbindlichen Anbieterangaben werden vor Veröffentlichung aus dem bestehenden Webauftritt übernommen.</p>
       <section><h2>Studio Animal-Aided Design</h2><p>Platzhalter für Anschrift, Vertretungsberechtigte und Kontaktangaben.</p></section>
-      <aside>Dieser Mock enthält bewusst keine erfundenen rechtlichen Angaben.</aside>
+      <aside>Vor dem öffentlichen Betrieb werden die Anbieterangaben vollständig ergänzt und rechtlich geprüft.</aside>
     </article><PublicFooter /></div></main>
   );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { ArrowRight, ArrowUpRight, Bird, Building2, Leaf, Search, Sparkles } from "lucide-react";
 import { SiteHeader } from "@/components/site-header";
 import { SpeciesCard } from "@/components/species-card";
+import { CatalogEntityCard } from "@/components/catalog-entity-card";
 import { PublicFooter } from "@/components/public-footer";
 import { EditorialActionLink, EditorialSectionHeading } from "@/components/editorial-primitives";
 import { catalogApi } from "@/lib/catalog/catalog-api";
@@ -86,6 +87,39 @@ export default async function Home() {
             {overview.featuredSpecies.map((species, index) => (
               <SpeciesCard key={species.slug} species={species} priority={index === 0} />
             ))}
+          </div>
+        </section>
+
+        <section className="catalog-preview-section" aria-labelledby="catalog-preview-title">
+          <EditorialSectionHeading
+            eyebrow="Planungswissen entdecken"
+            title="Pflanzen und Strukturen, die Arten unterstützen."
+            titleId="catalog-preview-title"
+            lede="Von der ökologischen Funktion zur umsetzbaren Auswahl: Entdecken Sie veröffentlichte Pflanzen und Habitatelemente aus der Datenbank."
+          />
+          <div className="catalog-preview-columns">
+            <section className="catalog-preview-group" aria-labelledby="featured-plants-title">
+              <header>
+                <div><Leaf aria-hidden="true" /><h3 id="featured-plants-title">Pflanzen</h3></div>
+                <EditorialActionLink href="/plants" variant="text">Alle Pflanzen</EditorialActionLink>
+              </header>
+              <div className="catalog-preview-cards">
+                {overview.featuredPlants.slice(0, 2).map((plant) => (
+                  <CatalogEntityCard key={plant.slug} kind="plant" item={plant} headingLevel={4} />
+                ))}
+              </div>
+            </section>
+            <section className="catalog-preview-group" aria-labelledby="featured-habitats-title">
+              <header>
+                <div><Building2 aria-hidden="true" /><h3 id="featured-habitats-title">Habitatelemente</h3></div>
+                <EditorialActionLink href="/habitat-elements" variant="text">Alle Habitatelemente</EditorialActionLink>
+              </header>
+              <div className="catalog-preview-cards">
+                {overview.featuredHabitats.slice(0, 2).map((habitat, index) => (
+                  <CatalogEntityCard key={habitat.slug} kind="habitat" item={habitat} priority={index === 0} headingLevel={4} />
+                ))}
+              </div>
+            </section>
           </div>
         </section>
 

--- a/apps/web/src/app/plants/[slug]/page.tsx
+++ b/apps/web/src/app/plants/[slug]/page.tsx
@@ -99,7 +99,7 @@ export default async function PlantDetailPage({ params }: PageProps) {
                   </Link>
                 ))}
               </div>
-            ) : <p className="empty-note">Beziehungen folgen mit der vollständigen Datenmigration.</p>}
+            ) : <p className="empty-note">Für diese Pflanze sind derzeit keine Zielart-Beziehungen hinterlegt.</p>}
           </section>
           <EditorialSourceNote sources={plant.sources.join(" · ")} />
         </article>

--- a/apps/web/src/app/plants/page.tsx
+++ b/apps/web/src/app/plants/page.tsx
@@ -15,7 +15,11 @@ type PageProps = { searchParams: Promise<{ q?: string; type?: string }> };
 
 export default async function PlantsPage({ searchParams }: PageProps) {
   const query = await searchParams;
-  const plants = (await catalogApi.listPlants(query)).filter((item) => item.status === "published");
+  const [listedPlants, catalogTypes] = await Promise.all([
+    catalogApi.listPlants(query),
+    catalogApi.getCatalogTypes()
+  ]);
+  const plants = listedPlants.filter((item) => item.status === "published");
 
   return (
     <main>
@@ -29,7 +33,7 @@ export default async function PlantsPage({ searchParams }: PageProps) {
             action="/plants"
             query={query.q}
             type={query.type}
-            types={["Gehölz", "Staude"]}
+            types={catalogTypes.plantTypes}
             searchLabel="Nach deutschem oder wissenschaftlichem Namen suchen"
           />
         </section>

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -9,7 +9,7 @@ export default function PrivacyPage() {
     <main><div className="page-shell"><SiteHeader /><article className="legal-page">
       <p className="eyebrow">Rechtliches</p><h1>Datenschutz</h1>
       <p>Die endgültige Datenschutzerklärung wird an Hosting, Protokollierung, Authentifizierung und Medienbereitstellung angepasst.</p>
-      <section><h2>Datensparsame Grundlage</h2><p>Die öffentlichen Mock-Seiten verwenden derzeit keine Konten, Analyse-Cookies oder Kontaktformulare.</p></section>
+      <section><h2>Datensparsame Grundlage</h2><p>Die öffentliche Anwendung verwendet derzeit keine Konten, Analyse-Cookies oder Kontaktformulare.</p></section>
       <aside>Vor dem öffentlichen Betrieb ist eine rechtliche Prüfung erforderlich.</aside>
     </article><PublicFooter /></div></main>
   );

--- a/apps/web/src/app/species/[slug]/page.tsx
+++ b/apps/web/src/app/species/[slug]/page.tsx
@@ -2,11 +2,12 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, ArrowRight, Bird, Leaf, MapPin, Sprout } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import { SiteHeader } from "@/components/site-header";
 import { PublicFooter } from "@/components/public-footer";
 import { EditorialEyebrow, EditorialFactList } from "@/components/editorial-primitives";
 import { SpeciesAttributeBrowser } from "@/components/species-attribute-browser";
+import { SpeciesPlanningBrowser } from "@/components/species-planning-browser";
 import { SpeciesPortraitNav } from "@/components/species-portrait-nav";
 import { catalogApi } from "@/lib/catalog/catalog-api";
 
@@ -117,28 +118,7 @@ export default async function SpeciesDetailPage({ params }: PageProps) {
               <p className="eyebrow">03 · In den Entwurf übersetzen</p>
               <h2>Planungsbausteine für den {species.commonName}</h2>
             </div>
-            <div className="planning-columns">
-              <div>
-                <div className="planning-heading"><Leaf /><span><small>Verknüpfte</small>Pflanzen</span></div>
-                {species.plants.length ? species.plants.map((plant) => (
-                  <Link className="relation-row" href={`/plants/${plant.slug}`} key={`${plant.scientificName}-${plant.purpose}`}>
-                    <Sprout size={18} />
-                    <div><strong>{plant.commonName}</strong><i>{plant.scientificName}</i></div>
-                    <span>{plant.purpose}</span>
-                  </Link>
-                )) : <p className="empty-note">Für dieses Artenportrait sind derzeit keine Pflanzenbeziehungen hinterlegt.</p>}
-              </div>
-              <div>
-                <div className="planning-heading"><MapPin /><span><small>Verknüpfte</small>Habitatelemente</span></div>
-                {species.habitats.length ? species.habitats.map((habitat) => (
-                  <Link className="relation-row" href={`/habitat-elements/${habitat.slug}`} key={`${habitat.slug}-${habitat.purpose}`}>
-                    <Bird size={18} />
-                    <div><strong>{habitat.name}</strong><i>{habitat.lifecycleStage}</i></div>
-                    <span>{habitat.purpose}</span>
-                  </Link>
-                )) : <p className="empty-note">Für dieses Artenportrait sind derzeit keine Habitatelement-Beziehungen hinterlegt.</p>}
-              </div>
-            </div>
+            <SpeciesPlanningBrowser plants={species.plants} habitats={species.habitats} />
           </section>
 
           <section className="portrait-cta">

--- a/apps/web/src/app/species/[slug]/page.tsx
+++ b/apps/web/src/app/species/[slug]/page.tsx
@@ -133,7 +133,7 @@ export default async function SpeciesDetailPage({ params }: PageProps) {
                     <div><strong>{plant.commonName}</strong><i>{plant.scientificName}</i></div>
                     <span>{plant.purpose}</span>
                   </Link>
-                )) : <p className="empty-note">Beziehungen folgen mit der Datenmigration.</p>}
+                )) : <p className="empty-note">Für dieses Artenportrait sind derzeit keine Pflanzenbeziehungen hinterlegt.</p>}
               </div>
               <div>
                 <div className="planning-heading"><MapPin /><span><small>Verknüpfte</small>Habitatelemente</span></div>
@@ -143,7 +143,7 @@ export default async function SpeciesDetailPage({ params }: PageProps) {
                     <div><strong>{habitat.name}</strong><i>{habitat.lifecycleStage}</i></div>
                     <span>{habitat.purpose}</span>
                   </Link>
-                )) : <p className="empty-note">Beziehungen folgen mit der Datenmigration.</p>}
+                )) : <p className="empty-note">Für dieses Artenportrait sind derzeit keine Habitatelement-Beziehungen hinterlegt.</p>}
               </div>
             </div>
           </section>

--- a/apps/web/src/app/species/[slug]/page.tsx
+++ b/apps/web/src/app/species/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { SiteHeader } from "@/components/site-header";
 import { PublicFooter } from "@/components/public-footer";
 import { EditorialEyebrow, EditorialFactList } from "@/components/editorial-primitives";
 import { SpeciesAttributeBrowser } from "@/components/species-attribute-browser";
+import { SpeciesPortraitNav } from "@/components/species-portrait-nav";
 import { catalogApi } from "@/lib/catalog/catalog-api";
 
 type PageProps = { params: Promise<{ slug: string }> };
@@ -83,11 +84,11 @@ export default async function SpeciesDetailPage({ params }: PageProps) {
             </div>
           </section>
 
-          <nav className="portrait-nav" aria-label="Abschnitte des Artenportraits">
-            <a href="#characteristics">Kurzcharakteristik</a>
-            <a href="#lifecycle">Lebenszyklus</a>
-            <a href="#planning">Planungsbausteine</a>
-          </nav>
+          <SpeciesPortraitNav
+            commonName={species.commonName}
+            scientificName={species.scientificName}
+            image={species.image}
+          />
 
           <section className="portrait-section" id="characteristics">
             <div className="portrait-section-title">

--- a/apps/web/src/app/species/[slug]/page.tsx
+++ b/apps/web/src/app/species/[slug]/page.tsx
@@ -2,10 +2,11 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, ArrowRight, Bird, Leaf, MapPin, Quote, Sprout } from "lucide-react";
+import { ArrowLeft, ArrowRight, Bird, Leaf, MapPin, Sprout } from "lucide-react";
 import { SiteHeader } from "@/components/site-header";
 import { PublicFooter } from "@/components/public-footer";
-import { EditorialEyebrow, EditorialFactList, EditorialSourceNote } from "@/components/editorial-primitives";
+import { EditorialEyebrow, EditorialFactList } from "@/components/editorial-primitives";
+import { SpeciesAttributeBrowser } from "@/components/species-attribute-browser";
 import { catalogApi } from "@/lib/catalog/catalog-api";
 
 type PageProps = { params: Promise<{ slug: string }> };
@@ -93,16 +94,7 @@ export default async function SpeciesDetailPage({ params }: PageProps) {
               <p className="eyebrow">01 · Art verstehen</p>
               <h2>Kurzcharakteristik</h2>
             </div>
-            <div className="attribute-list">
-              {species.attributes.map((attribute) => (
-                <div className="attribute-item" key={`${attribute.category}-${attribute.label}`}>
-                  <p>{attribute.category}</p>
-                  <h3>{attribute.label}</h3>
-                  <blockquote><Quote size={18} />{attribute.value}</blockquote>
-                  {attribute.sources && <EditorialSourceNote sources={attribute.sources} compact />}
-                </div>
-              ))}
-            </div>
+            <SpeciesAttributeBrowser attributes={species.attributes} />
           </section>
 
           <section className="lifecycle-section" id="lifecycle">

--- a/apps/web/src/app/species/page.tsx
+++ b/apps/web/src/app/species/page.tsx
@@ -15,7 +15,11 @@ type PageProps = { searchParams: Promise<{ q?: string; type?: string }> };
 
 export default async function SpeciesPage({ searchParams }: PageProps) {
   const query = await searchParams;
-  const species = (await catalogApi.listSpecies(query)).filter((item) => item.status === "published");
+  const [listedSpecies, catalogTypes] = await Promise.all([
+    catalogApi.listSpecies(query),
+    catalogApi.getCatalogTypes()
+  ]);
+  const species = listedSpecies.filter((item) => item.status === "published");
 
   return (
     <main>
@@ -29,13 +33,13 @@ export default async function SpeciesPage({ searchParams }: PageProps) {
             action="/species"
             query={query.q}
             type={query.type}
-            types={["Vögel", "Insekten", "Reptilien", "Säugetiere"]}
+            types={catalogTypes.speciesTypes}
             searchLabel="Nach Name, Klasse oder Familie suchen"
           />
         </section>
         {species.length ? (
           <section className="species-grid catalog-grid" aria-label="Artenportraits">
-            {species.map((item, index) => <SpeciesCard key={item.slug} species={item} priority={index === 0} />)}
+            {species.map((item, index) => <SpeciesCard key={item.slug} species={item} priority={index === 0} headingLevel={2} />)}
           </section>
         ) : (
           <EditorialEmptyState

--- a/apps/web/src/components/catalog-entity-card.tsx
+++ b/apps/web/src/components/catalog-entity-card.tsx
@@ -4,14 +4,15 @@ import { Building2, Leaf } from "lucide-react";
 import { EditorialActionLink, EditorialEyebrow } from "@/components/editorial-primitives";
 import type { HabitatSummary, PlantSummary } from "@/lib/catalog/types";
 
-type PlantCardProps = { kind: "plant"; item: PlantSummary };
-type HabitatCardProps = { kind: "habitat"; item: HabitatSummary; priority?: boolean };
+type PlantCardProps = { kind: "plant"; item: PlantSummary; headingLevel?: 2 | 3 | 4 };
+type HabitatCardProps = { kind: "habitat"; item: HabitatSummary; priority?: boolean; headingLevel?: 2 | 3 | 4 };
 
 export function CatalogEntityCard(props: PlantCardProps | HabitatCardProps) {
   const isPlant = props.kind === "plant";
   const href = props.kind === "plant" ? `/plants/${props.item.slug}` : `/habitat-elements/${props.item.slug}`;
   const title = props.kind === "plant" ? props.item.commonName : props.item.name;
   const label = props.item.type;
+  const Heading = props.headingLevel === 3 ? "h3" : props.headingLevel === 4 ? "h4" : "h2";
 
   return (
     <article className={`entity-card ${isPlant ? "plant-card" : "habitat-card"}`}>
@@ -25,8 +26,8 @@ export function CatalogEntityCard(props: PlantCardProps | HabitatCardProps) {
             sizes="(max-width: 720px) 92vw, 31vw"
           />
         ) : (
-          <div className="botanical-mark" aria-hidden="true">
-            <Leaf />
+          <div className={`botanical-mark ${isPlant ? "botanical-mark-plant" : "botanical-mark-habitat"}`} aria-hidden="true">
+            {isPlant ? <Leaf /> : <Building2 />}
             <i />
             <i />
           </div>
@@ -35,7 +36,7 @@ export function CatalogEntityCard(props: PlantCardProps | HabitatCardProps) {
       </Link>
       <div className="entity-card-content">
         <EditorialEyebrow>{props.kind === "plant" ? props.item.floweringPeriod ?? "Pflanzenart" : props.item.location ?? "Planungsbaustein"}</EditorialEyebrow>
-        <h2><Link href={href}>{title}</Link></h2>
+        <Heading><Link href={href}>{title}</Link></Heading>
         {props.kind === "plant" && <p className="scientific">{props.item.scientificName}</p>}
         <p>{props.item.teaser}</p>
         <EditorialActionLink variant="text" href={href}>Details öffnen</EditorialActionLink>

--- a/apps/web/src/components/species-attribute-browser.test.tsx
+++ b/apps/web/src/components/species-attribute-browser.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { SpeciesAttribute } from "@/lib/catalog/types";
+import { groupSpeciesAttributes, SpeciesAttributeBrowser } from "./species-attribute-browser";
+
+const attributes: SpeciesAttribute[] = [
+  {
+    category: "Kurzcharakteristik",
+    subcategory: "Aussehen und Körperbau",
+    label: "Aussehen",
+    value: "Rote Unterseite.",
+    sources: "Beispielquelle"
+  },
+  {
+    category: "Kurzcharakteristik",
+    subcategory: "Aussehen und Körperbau",
+    label: "Morphologie",
+    value: "Kompakter Körperbau."
+  },
+  {
+    category: "Bedeutung für den Menschen",
+    subcategory: "Wahrnehmung",
+    label: "Beobachtbarkeit",
+    value: "Gut zu erkennen."
+  }
+];
+
+describe("SpeciesAttributeBrowser", () => {
+  it("preserves canonical category and subgroup order while deriving counts", () => {
+    const grouped = groupSpeciesAttributes(attributes);
+
+    expect(grouped.map((category) => [category.name, category.count])).toEqual([
+      ["Kurzcharakteristik", 2],
+      ["Bedeutung für den Menschen", 1]
+    ]);
+    expect(grouped[0].subgroups.map((subgroup) => subgroup.name)).toEqual(["Aussehen und Körperbau"]);
+    expect(grouped[0].subgroups[0].attributes.map((attribute) => attribute.label)).toEqual(["Aussehen", "Morphologie"]);
+  });
+
+  it("server-renders the full editorial index, disclosures, values, and sources", () => {
+    const html = renderToStaticMarkup(<SpeciesAttributeBrowser attributes={attributes} />);
+
+    expect(html).toContain('aria-label="Themenfilter für die Artenmerkmale"');
+    expect(html).toContain('href="#merkmale-kurzcharakteristik"');
+    expect(html).toContain("Aussehen und Körperbau");
+    expect(html).toContain("Rote Unterseite.");
+    expect(html).toContain("Beispielquelle");
+    expect(html).toContain("<details");
+    expect(html).not.toContain("overflow");
+  });
+
+  it("renders a useful sparse-data state", () => {
+    const html = renderToStaticMarkup(<SpeciesAttributeBrowser attributes={[]} />);
+
+    expect(html).toContain("keine Merkmale veröffentlicht");
+    expect(html).not.toContain("<nav");
+  });
+});

--- a/apps/web/src/components/species-attribute-browser.tsx
+++ b/apps/web/src/components/species-attribute-browser.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect } from "react";
+import { ChevronRight, Quote } from "lucide-react";
+import type { SpeciesAttribute } from "@/lib/catalog/types";
+import { EditorialSourceNote } from "./editorial-primitives";
+
+type AttributeSubgroup = {
+  id: string;
+  name: string;
+  attributes: SpeciesAttribute[];
+};
+
+export type AttributeCategory = {
+  id: string;
+  name: string;
+  count: number;
+  subgroups: AttributeSubgroup[];
+};
+
+function anchorSlug(value: string) {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase("de")
+    .replace(/ß/g, "ss")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function groupSpeciesAttributes(attributes: SpeciesAttribute[]): AttributeCategory[] {
+  const categories = new Map<string, { attributes: SpeciesAttribute[]; subgroups: Map<string, SpeciesAttribute[]> }>();
+
+  for (const attribute of attributes) {
+    const category = categories.get(attribute.category) ?? {
+      attributes: [] as SpeciesAttribute[],
+      subgroups: new Map<string, SpeciesAttribute[]>()
+    };
+    category.attributes.push(attribute);
+    const subgroupName = attribute.subcategory || attribute.category;
+    const subgroup = category.subgroups.get(subgroupName) ?? ([] as SpeciesAttribute[]);
+    subgroup.push(attribute);
+    category.subgroups.set(subgroupName, subgroup);
+    categories.set(attribute.category, category);
+  }
+
+  return [...categories].map(([name, category]) => {
+    const categoryId = `merkmale-${anchorSlug(name)}`;
+    return {
+      id: categoryId,
+      name,
+      count: category.attributes.length,
+      subgroups: [...category.subgroups].map(([subgroupName, subgroupAttributes]) => ({
+        id: `${categoryId}-${anchorSlug(subgroupName)}`,
+        name: subgroupName,
+        attributes: subgroupAttributes
+      }))
+    };
+  });
+}
+
+export function SpeciesAttributeBrowser({ attributes }: { attributes: SpeciesAttribute[] }) {
+  const categories = groupSpeciesAttributes(attributes);
+
+  useEffect(() => {
+    const links = [...document.querySelectorAll<HTMLAnchorElement>("[data-attribute-index-link]")];
+    const sections = [...document.querySelectorAll<HTMLElement>("[data-attribute-category]")];
+    if (!links.length || !sections.length || !("IntersectionObserver" in window)) return;
+
+    const setCurrent = (id: string) => {
+      links.forEach((link) => link.setAttribute("aria-current", link.hash === `#${id}` ? "location" : "false"));
+    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((left, right) => left.boundingClientRect.top - right.boundingClientRect.top)[0];
+        if (visible?.target.id) setCurrent(visible.target.id);
+      },
+      { rootMargin: "-18% 0px -68% 0px", threshold: 0 }
+    );
+    sections.forEach((section) => observer.observe(section));
+    return () => observer.disconnect();
+  }, []);
+
+  if (!categories.length) {
+    return <p className="empty-note">Für dieses Artenportrait sind derzeit keine Merkmale veröffentlicht.</p>;
+  }
+
+  return (
+    <div className="attribute-browser">
+      <nav className="attribute-index" aria-label="Themenfilter für die Artenmerkmale">
+        <p>Direkt zu</p>
+        <ol>
+          {categories.map((category, index) => (
+            <li key={category.id}>
+              <a
+                href={`#${category.id}`}
+                data-attribute-index-link
+                aria-current={index === 0 ? "location" : "false"}
+              >
+                <span>{category.name}</span>
+                <small>{category.count}</small>
+              </a>
+            </li>
+          ))}
+        </ol>
+      </nav>
+
+      <div className="attribute-categories">
+        {categories.map((category, categoryIndex) => (
+          <section
+            className="attribute-category"
+            id={category.id}
+            data-attribute-category
+            aria-labelledby={`${category.id}-title`}
+            key={category.id}
+          >
+            <header>
+              <p>Merkmalsbereich</p>
+              <h3 id={`${category.id}-title`}>{category.name}</h3>
+              <span>{category.count} {category.count === 1 ? "Merkmal" : "Merkmale"}</span>
+            </header>
+            <div className="attribute-groups">
+              {category.subgroups.map((subgroup, subgroupIndex) => (
+                <details
+                  className="attribute-group"
+                  id={subgroup.id}
+                  open={categoryIndex === 0 && subgroupIndex === 0}
+                  key={subgroup.id}
+                >
+                  <summary>
+                    <ChevronRight aria-hidden="true" />
+                    <span>{subgroup.name}</span>
+                    <small>{subgroup.attributes.length} {subgroup.attributes.length === 1 ? "Eintrag" : "Einträge"}</small>
+                  </summary>
+                  <div className="attribute-group-content">
+                    {subgroup.attributes.map((attribute) => (
+                      <article className="attribute-item" key={`${attribute.category}-${attribute.subcategory}-${attribute.label}`}>
+                        <h4>{attribute.label}</h4>
+                        <blockquote><Quote size={18} aria-hidden="true" /><span>{attribute.value}</span></blockquote>
+                        {attribute.sources && <EditorialSourceNote sources={attribute.sources} compact />}
+                      </article>
+                    ))}
+                  </div>
+                </details>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/species-card.tsx
+++ b/apps/web/src/components/species-card.tsx
@@ -3,7 +3,17 @@ import Link from "next/link";
 import { EditorialActionLink, EditorialEyebrow } from "@/components/editorial-primitives";
 import type { SpeciesSummary } from "@/lib/catalog/types";
 
-export function SpeciesCard({ species, priority = false }: { species: SpeciesSummary; priority?: boolean }) {
+export function SpeciesCard({
+  species,
+  priority = false,
+  headingLevel = 3
+}: {
+  species: SpeciesSummary;
+  priority?: boolean;
+  headingLevel?: 2 | 3;
+}) {
+  const Heading = headingLevel === 2 ? "h2" : "h3";
+
   return (
     <article className="species-card">
       <Link href={`/species/${species.slug}`} className="species-image">
@@ -18,9 +28,9 @@ export function SpeciesCard({ species, priority = false }: { species: SpeciesSum
       </Link>
       <div className="species-card-content">
         <EditorialEyebrow>{species.familyName}</EditorialEyebrow>
-        <h3>
+        <Heading>
           <Link href={`/species/${species.slug}`}>{species.commonName}</Link>
-        </h3>
+        </Heading>
         <p className="scientific">{species.scientificName}</p>
         <p>{species.teaser}</p>
         <EditorialActionLink variant="text" href={`/species/${species.slug}`}>

--- a/apps/web/src/components/species-planning-browser.test.tsx
+++ b/apps/web/src/components/species-planning-browser.test.tsx
@@ -1,0 +1,104 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { RelatedHabitat, RelatedPlant } from "@/lib/catalog/types";
+import {
+  buildPlanningItems,
+  filterPlanningItems,
+  groupPlanningItems,
+  planningFunctionIds,
+  SpeciesPlanningBrowser
+} from "./species-planning-browser";
+
+const plants: RelatedPlant[] = [
+  { slug: "acer-campestre", commonName: "Feld-Ahorn", scientificName: "Acer campestre", purpose: "Nahrung (Samen, Knospen)" },
+  { slug: "cornus-mas", commonName: "Kornelkirsche", scientificName: "Cornus mas", purpose: "Schutzgehölz, Nahrung (Samen, Früchte)" },
+  { slug: "picea-abies", commonName: "Fichte", scientificName: "Picea abies", purpose: "Schutz- und Nistgehölz" },
+  { slug: "plant-4", commonName: "Pflanze vier", scientificName: "Planta IV", purpose: "Nahrung (Samen)" },
+  { slug: "plant-5", commonName: "Pflanze fünf", scientificName: "Planta V", purpose: "Nahrung (Samen)" },
+  { slug: "plant-6", commonName: "Pflanze sechs", scientificName: "Planta VI", purpose: "Nahrung (Samen)" },
+  { slug: "plant-7", commonName: "Pflanze sieben", scientificName: "Planta VII", purpose: "Nahrung (Samen)" }
+];
+
+const habitats: RelatedHabitat[] = [
+  {
+    slug: "wild-hecken",
+    name: "(Wild-)Hecken",
+    purpose: "Brutplatz",
+    purposeElement: "Dichte Zweige",
+    lifecycleStage: "adult"
+  },
+  {
+    slug: "altgrasstreifen",
+    name: "Altgrasstreifen",
+    purpose: "Nahrung",
+    purposeElement: "Samen",
+    lifecycleStage: "adult, juvenil"
+  },
+  {
+    slug: "dichte-straeucher",
+    name: "Dichte Sträucher",
+    purpose: "Schlafplatz",
+    purposeElement: "Deckung",
+    lifecycleStage: "adult, juvenil"
+  }
+];
+
+describe("SpeciesPlanningBrowser", () => {
+  it("maps raw relationship purposes into stable planning-function families", () => {
+    expect(planningFunctionIds("Schutz- und Nistgehölz, Nahrung (Samen)")).toEqual([
+      "food",
+      "shelter",
+      "nesting"
+    ]);
+    expect(planningFunctionIds("Schlafplatz")).toEqual(["sleeping"]);
+    expect(planningFunctionIds("Sonderfunktion")).toEqual(["other"]);
+  });
+
+  it("filters relationships by entity, lifecycle stage, and searchable content", () => {
+    const items = buildPlanningItems(plants, habitats);
+
+    expect(filterPlanningItems(items, "", "plant", "all")).toHaveLength(7);
+    expect(filterPlanningItems(items, "", "all", "juvenil").map((item) => item.name)).toEqual([
+      "Altgrasstreifen",
+      "Dichte Sträucher"
+    ]);
+    expect(filterPlanningItems(items, "Zweige", "all", "all").map((item) => item.name)).toEqual([
+      "(Wild-)Hecken"
+    ]);
+  });
+
+  it("groups multi-function relationships into each relevant editorial chapter", () => {
+    const groups = groupPlanningItems(buildPlanningItems(plants, habitats));
+    const fichteGroups = groups
+      .filter((group) => group.items.some((item) => item.name === "Fichte"))
+      .map((group) => group.id);
+
+    expect(fichteGroups).toEqual(["shelter", "nesting"]);
+    expect(groups.map((group) => group.name)).toEqual([
+      "Nahrung",
+      "Schutz und Rückzug",
+      "Brut und Nisten",
+      "Schlafplatz"
+    ]);
+  });
+
+  it("server-renders filters, chapters, all relationship content, and progressive reveal", () => {
+    const html = renderToStaticMarkup(<SpeciesPlanningBrowser plants={plants} habitats={habitats} />);
+
+    expect(html).toContain('aria-label="Entitätstyp filtern"');
+    expect(html).toContain('aria-label="Lebensphase filtern"');
+    expect(html).toContain("Nahrung");
+    expect(html).toContain("Brut und Nisten");
+    expect(html).toContain("Pflanze sieben");
+    expect(html).toContain("Weitere 1 anzeigen");
+    expect(html).toContain("Dichte Zweige");
+    expect(html).not.toContain("overflow");
+  });
+
+  it("renders a useful sparse-data state", () => {
+    const html = renderToStaticMarkup(<SpeciesPlanningBrowser plants={[]} habitats={[]} />);
+
+    expect(html).toContain("keine Planungsbausteine veröffentlicht");
+    expect(html).not.toContain("planning-browser-toolbar");
+  });
+});

--- a/apps/web/src/components/species-planning-browser.tsx
+++ b/apps/web/src/components/species-planning-browser.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import Link from "next/link";
+import { Bird, ChevronRight, RotateCcw, Search, Sprout } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import type { RelatedHabitat, RelatedPlant } from "@/lib/catalog/types";
+
+const INITIAL_VISIBLE_ITEMS = 6;
+const REVEAL_STEP = 12;
+
+export type PlanningEntityType = "all" | "plant" | "habitat";
+export type PlanningLifecycleStage = "all" | "adult" | "juvenil";
+export type PlanningFunctionId = "food" | "shelter" | "nesting" | "sleeping" | "other";
+
+export type PlanningItem = {
+  id: string;
+  entityType: Exclude<PlanningEntityType, "all">;
+  slug: string;
+  name: string;
+  scientificName?: string;
+  purpose: string;
+  purposeElement?: string;
+  lifecycleStage?: string;
+  functionIds: PlanningFunctionId[];
+};
+
+export type PlanningGroup = {
+  id: PlanningFunctionId;
+  name: string;
+  description: string;
+  items: PlanningItem[];
+};
+
+const planningFunctions: Array<Omit<PlanningGroup, "items">> = [
+  { id: "food", name: "Nahrung", description: "Futterquellen und nahrungsrelevante Strukturen" },
+  { id: "shelter", name: "Schutz und Rückzug", description: "Deckung, Schutzgehölze und Rückzugsräume" },
+  { id: "nesting", name: "Brut und Nisten", description: "Brutplätze, Nistgehölze und Aufzuchtstrukturen" },
+  { id: "sleeping", name: "Schlafplatz", description: "Geschützte Ruhe- und Schlafplätze" },
+  { id: "other", name: "Weitere Funktionen", description: "Noch nicht kanonisch zugeordnete Beziehungen" }
+];
+
+export function planningFunctionIds(purpose: string): PlanningFunctionId[] {
+  const normalized = purpose.toLocaleLowerCase("de");
+  const ids: PlanningFunctionId[] = [];
+  if (/nahrung|futter/.test(normalized)) ids.push("food");
+  if (/schutz|rückzug|deckung/.test(normalized)) ids.push("shelter");
+  if (/brut|nist/.test(normalized)) ids.push("nesting");
+  if (/schlaf/.test(normalized)) ids.push("sleeping");
+  return ids.length ? ids : ["other"];
+}
+
+export function buildPlanningItems(plants: RelatedPlant[], habitats: RelatedHabitat[]): PlanningItem[] {
+  return [
+    ...plants.map((plant, index): PlanningItem => ({
+      id: `plant-${index}-${plant.slug}-${plant.purpose}`,
+      entityType: "plant",
+      slug: plant.slug,
+      name: plant.commonName,
+      scientificName: plant.scientificName,
+      purpose: plant.purpose,
+      functionIds: planningFunctionIds(plant.purpose)
+    })),
+    ...habitats.map((habitat, index): PlanningItem => ({
+      id: `habitat-${index}-${habitat.slug}-${habitat.purpose}-${habitat.lifecycleStage}`,
+      entityType: "habitat",
+      slug: habitat.slug,
+      name: habitat.name,
+      purpose: habitat.purpose,
+      purposeElement: habitat.purposeElement,
+      lifecycleStage: habitat.lifecycleStage,
+      functionIds: planningFunctionIds(habitat.purpose)
+    }))
+  ];
+}
+
+export function filterPlanningItems(
+  items: PlanningItem[],
+  query: string,
+  entityType: PlanningEntityType,
+  lifecycleStage: PlanningLifecycleStage
+) {
+  const normalizedQuery = query.trim().toLocaleLowerCase("de");
+  return items.filter((item) => {
+    if (entityType !== "all" && item.entityType !== entityType) return false;
+    if (lifecycleStage !== "all") {
+      if (item.entityType !== "habitat") return false;
+      const stages = item.lifecycleStage?.toLocaleLowerCase("de") ?? "";
+      if (!stages.includes(lifecycleStage)) return false;
+    }
+    if (!normalizedQuery) return true;
+    return [item.name, item.scientificName, item.purpose, item.purposeElement, item.lifecycleStage]
+      .filter(Boolean)
+      .some((value) => value?.toLocaleLowerCase("de").includes(normalizedQuery));
+  });
+}
+
+export function groupPlanningItems(items: PlanningItem[]): PlanningGroup[] {
+  return planningFunctions
+    .map((group) => ({ ...group, items: items.filter((item) => item.functionIds.includes(group.id)) }))
+    .filter((group) => group.items.length > 0);
+}
+
+function FilterButton({
+  active,
+  children,
+  onClick
+}: {
+  active: boolean;
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" aria-pressed={active} onClick={onClick}>
+      {children}
+    </button>
+  );
+}
+
+export function SpeciesPlanningBrowser({
+  plants,
+  habitats
+}: {
+  plants: RelatedPlant[];
+  habitats: RelatedHabitat[];
+}) {
+  const allItems = useMemo(() => buildPlanningItems(plants, habitats), [plants, habitats]);
+  const [query, setQuery] = useState("");
+  const [entityType, setEntityType] = useState<PlanningEntityType>("all");
+  const [lifecycleStage, setLifecycleStage] = useState<PlanningLifecycleStage>("all");
+  const [visibleByGroup, setVisibleByGroup] = useState<Record<string, number>>({});
+  const filteredItems = useMemo(
+    () => filterPlanningItems(allItems, query, entityType, lifecycleStage),
+    [allItems, query, entityType, lifecycleStage]
+  );
+  const groups = useMemo(() => groupPlanningItems(filteredItems), [filteredItems]);
+  const filtersActive = Boolean(query || entityType !== "all" || lifecycleStage !== "all");
+
+  if (!allItems.length) {
+    return <p className="empty-note">Für dieses Artenportrait sind derzeit keine Planungsbausteine veröffentlicht.</p>;
+  }
+
+  const resetFilters = () => {
+    setQuery("");
+    setEntityType("all");
+    setLifecycleStage("all");
+  };
+
+  return (
+    <div className="planning-browser">
+      <div className="planning-browser-toolbar">
+        <label className="planning-search">
+          <Search size={17} aria-hidden="true" />
+          <span className="sr-only">Planungsbaustein suchen</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setVisibleByGroup({});
+            }}
+            placeholder="Name oder Funktion suchen"
+          />
+        </label>
+
+        <div className="planning-filter-group planning-filter-type" aria-label="Entitätstyp filtern">
+          <FilterButton active={entityType === "all"} onClick={() => { setEntityType("all"); setVisibleByGroup({}); }}>Alle Typen</FilterButton>
+          <FilterButton active={entityType === "plant"} onClick={() => { setEntityType("plant"); setVisibleByGroup({}); }}>Pflanzen</FilterButton>
+          <FilterButton active={entityType === "habitat"} onClick={() => { setEntityType("habitat"); setVisibleByGroup({}); }}>Habitatelemente</FilterButton>
+        </div>
+
+        <div className="planning-filter-group planning-filter-stage" aria-label="Lebensphase filtern">
+          <FilterButton active={lifecycleStage === "all"} onClick={() => { setLifecycleStage("all"); setVisibleByGroup({}); }}>Alle Phasen</FilterButton>
+          <FilterButton active={lifecycleStage === "adult"} onClick={() => { setLifecycleStage("adult"); setVisibleByGroup({}); }}>adult</FilterButton>
+          <FilterButton active={lifecycleStage === "juvenil"} onClick={() => { setLifecycleStage("juvenil"); setVisibleByGroup({}); }}>juvenil</FilterButton>
+        </div>
+
+        <div className="planning-result-summary" aria-live="polite">
+          <strong>{filteredItems.length}</strong> {filteredItems.length === 1 ? "Beziehung" : "Beziehungen"}
+          {filtersActive && (
+            <button type="button" onClick={resetFilters}>
+              <RotateCcw size={14} aria-hidden="true" /> Filter zurücksetzen
+            </button>
+          )}
+        </div>
+      </div>
+
+      {groups.length ? (
+        <div className="planning-function-groups">
+          {groups.map((group, groupIndex) => {
+            const visibleCount = visibleByGroup[group.id] ?? INITIAL_VISIBLE_ITEMS;
+            const remaining = Math.max(0, group.items.length - visibleCount);
+            return (
+              <details className="planning-function-group" open={groupIndex === 0} key={group.id}>
+                <summary>
+                  <ChevronRight aria-hidden="true" />
+                  <span>
+                    <strong>{group.name}</strong>
+                    <small>{group.description}</small>
+                  </span>
+                  <em>{group.items.length} {group.items.length === 1 ? "Beziehung" : "Beziehungen"}</em>
+                </summary>
+                <div className="planning-function-content">
+                  <div className="planning-relation-grid">
+                    {group.items.map((item, index) => (
+                      <Link
+                        className="planning-relation"
+                        href={item.entityType === "plant" ? `/plants/${item.slug}` : `/habitat-elements/${item.slug}`}
+                        hidden={index >= visibleCount}
+                        key={`${group.id}-${item.id}`}
+                      >
+                        {item.entityType === "plant" ? <Sprout aria-hidden="true" /> : <Bird aria-hidden="true" />}
+                        <span>
+                          <strong>{item.name}</strong>
+                          <i>{item.scientificName || item.lifecycleStage || "Habitatelement"}</i>
+                        </span>
+                        <small>
+                          {item.purposeElement && <em>{item.purposeElement}</em>}
+                          {item.purpose}
+                        </small>
+                      </Link>
+                    ))}
+                  </div>
+                  {remaining > 0 && (
+                    <button
+                      className="planning-reveal"
+                      type="button"
+                      onClick={() => setVisibleByGroup((current) => ({
+                        ...current,
+                        [group.id]: visibleCount + REVEAL_STEP
+                      }))}
+                    >
+                      Weitere {remaining} anzeigen
+                    </button>
+                  )}
+                </div>
+              </details>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="planning-empty" aria-live="polite">
+          <p>Für diese Filterkombination wurden keine Planungsbausteine gefunden.</p>
+          <button type="button" onClick={resetFilters}>Alle Filter zurücksetzen</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/species-portrait-nav.test.tsx
+++ b/apps/web/src/components/species-portrait-nav.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { selectActivePortraitSection, SpeciesPortraitNav } from "./species-portrait-nav";
+
+const image = {
+  url: "/landing/bird.webp",
+  alt: "Gimpel im Schnee",
+  attribution: "Beispielquelle",
+  type: "portrait" as const
+};
+
+describe("SpeciesPortraitNav", () => {
+  it("server-renders species context and all section links", () => {
+    const html = renderToStaticMarkup(
+      <SpeciesPortraitNav commonName="Gimpel" scientificName="Pyrrhula pyrrhula" image={image} />
+    );
+
+    expect(html).toContain('aria-label="Abschnitte des Artenportraits"');
+    expect(html).toContain("Gimpel");
+    expect(html).toContain("Pyrrhula pyrrhula");
+    expect(html).toContain('href="#characteristics"');
+    expect(html).toContain('href="#lifecycle"');
+    expect(html).toContain('href="#planning"');
+    expect(html).toContain('aria-current="location"');
+    expect(html).toContain('alt=""');
+  });
+
+  it("selects the last section whose top crossed the viewport marker", () => {
+    const positions = [
+      { id: "characteristics", top: -500 },
+      { id: "lifecycle", top: 120 },
+      { id: "planning", top: 900 }
+    ];
+
+    expect(selectActivePortraitSection(positions, 240)).toBe("lifecycle");
+    expect(selectActivePortraitSection(positions, 80)).toBe("characteristics");
+  });
+});

--- a/apps/web/src/components/species-portrait-nav.tsx
+++ b/apps/web/src/components/species-portrait-nav.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+import type { ImageAsset } from "@/lib/catalog/types";
+
+const portraitSections = [
+  { id: "characteristics", label: "Kurzcharakteristik" },
+  { id: "lifecycle", label: "Lebenszyklus" },
+  { id: "planning", label: "Planungsbausteine" }
+] as const;
+
+export function selectActivePortraitSection(
+  positions: Array<{ id: string; top: number }>,
+  marker: number
+) {
+  let active = positions[0]?.id ?? portraitSections[0].id;
+  for (const position of positions) {
+    if (position.top > marker) break;
+    active = position.id;
+  }
+  return active;
+}
+
+export function SpeciesPortraitNav({
+  commonName,
+  scientificName,
+  image
+}: {
+  commonName: string;
+  scientificName: string;
+  image: ImageAsset;
+}) {
+  const sentinelRef = useRef<HTMLSpanElement>(null);
+  const frameRef = useRef<number | null>(null);
+  const [isStuck, setIsStuck] = useState(false);
+  const [activeSection, setActiveSection] = useState<string>(portraitSections[0].id);
+
+  useEffect(() => {
+    const update = () => {
+      frameRef.current = null;
+      const sentinelTop = sentinelRef.current?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY;
+      setIsStuck(sentinelTop <= 12);
+
+      const marker = Math.min(240, window.innerHeight * 0.32);
+      const positions = portraitSections.flatMap(({ id }) => {
+        const section = document.getElementById(id);
+        return section ? [{ id, top: section.getBoundingClientRect().top }] : [];
+      });
+      setActiveSection(selectActivePortraitSection(positions, marker));
+    };
+    const scheduleUpdate = () => {
+      if (frameRef.current === null) frameRef.current = window.requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener("scroll", scheduleUpdate, { passive: true });
+    window.addEventListener("resize", scheduleUpdate);
+    return () => {
+      window.removeEventListener("scroll", scheduleUpdate);
+      window.removeEventListener("resize", scheduleUpdate);
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, []);
+
+  return (
+    <>
+      <span className="portrait-nav-sentinel" ref={sentinelRef} aria-hidden="true" />
+      <nav className={`portrait-nav${isStuck ? " is-stuck" : ""}`} aria-label="Abschnitte des Artenportraits">
+        <div className="portrait-nav-identity" aria-hidden={!isStuck}>
+          <span className="portrait-nav-thumbnail">
+            <Image src={image.url} alt="" width={42} height={42} sizes="42px" />
+          </span>
+          <span className="portrait-nav-names">
+            <strong>{commonName}</strong>
+            <i>{scientificName}</i>
+          </span>
+        </div>
+        <div className="portrait-nav-links">
+          {portraitSections.map((section) => (
+            <a
+              href={`#${section.id}`}
+              aria-current={activeSection === section.id ? "location" : undefined}
+              onClick={() => setActiveSection(section.id)}
+              key={section.id}
+            >
+              {section.label}
+            </a>
+          ))}
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/apps/web/src/lib/catalog/catalog-api.ts
+++ b/apps/web/src/lib/catalog/catalog-api.ts
@@ -32,6 +32,7 @@ class DevelopmentFallbackCatalogApi implements CatalogApi {
   }
 
   getOverview = () => this.call("getOverview", (api) => api.getOverview());
+  getCatalogTypes = () => this.call("getCatalogTypes", (api) => api.getCatalogTypes());
   listSpecies = (query?: Parameters<CatalogApi["listSpecies"]>[0]) => this.call("listSpecies", (api) => api.listSpecies(query));
   getSpeciesBySlug = (slug: string) => this.call("getSpeciesBySlug", (api) => api.getSpeciesBySlug(slug));
   listPlants = (query?: Parameters<CatalogApi["listPlants"]>[0]) => this.call("listPlants", (api) => api.listPlants(query));

--- a/apps/web/src/lib/catalog/featured-content.test.ts
+++ b/apps/web/src/lib/catalog/featured-content.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { selectFeatured, uniquePublishedTypes } from "./featured-content";
+
+const records = [
+  { slug: "zeta", status: "published" as const, type: "Staude" },
+  { slug: "preferred", status: "published" as const, type: "Gehölz" },
+  { slug: "alpha", status: "published" as const, type: "Staude" },
+  { slug: "draft", status: "draft" as const, type: "Einjährige" }
+];
+
+describe("featured content policy", () => {
+  it("keeps editorial preferences and fills gaps deterministically", () => {
+    expect(selectFeatured(records, ["missing", "preferred"], 3).map((item) => item.slug))
+      .toEqual(["preferred", "alpha", "zeta"]);
+  });
+
+  it("excludes unpublished records from features and filter facets", () => {
+    expect(selectFeatured(records, ["draft"], 5).map((item) => item.slug))
+      .toEqual(["alpha", "preferred", "zeta"]);
+    expect(uniquePublishedTypes(records)).toEqual(["Gehölz", "Staude"]);
+  });
+});

--- a/apps/web/src/lib/catalog/featured-content.ts
+++ b/apps/web/src/lib/catalog/featured-content.ts
@@ -1,0 +1,39 @@
+type Publishable = { slug: string; status: "draft" | "published" | "archived" };
+
+export const featuredSlugs = {
+  species: ["gimpel", "mauersegler", "zauneidechse"],
+  plants: ["acer-campestre", "betula-pendula", "cornus-mas"],
+  habitats: ["wild-hecken", "altgrasstreifen", "trockenmauer"]
+} as const;
+
+/**
+ * Select preferred published records in editorial order, then fill open slots
+ * by slug. This keeps the homepage stable while allowing incomplete imports.
+ */
+export function selectFeatured<T extends Publishable>(
+  items: T[],
+  preferred: readonly string[],
+  limit = 3
+): T[] {
+  const published = items.filter((item) => item.status === "published");
+  const bySlug = new Map(published.map((item) => [item.slug, item]));
+  const selected = preferred.flatMap((slug) => {
+    const item = bySlug.get(slug);
+    return item ? [item] : [];
+  });
+  const selectedSlugs = new Set(selected.map((item) => item.slug));
+  const fallback = published
+    .filter((item) => !selectedSlugs.has(item.slug))
+    .sort((left, right) => left.slug.localeCompare(right.slug, "de"));
+
+  return [...selected, ...fallback].slice(0, limit);
+}
+
+export function uniquePublishedTypes(items: Array<Publishable & { type?: string; className?: string }>): string[] {
+  return [...new Set(
+    items
+      .filter((item) => item.status === "published")
+      .map((item) => item.type ?? item.className)
+      .filter((value): value is string => Boolean(value?.trim()))
+  )].sort((left, right) => left.localeCompare(right, "de"));
+}

--- a/apps/web/src/lib/catalog/mock-api.test.ts
+++ b/apps/web/src/lib/catalog/mock-api.test.ts
@@ -34,6 +34,15 @@ describe("MockCatalogApi", () => {
     await expect(catalogApi.getHabitatBySlug("unbekannt")).resolves.toBeNull();
   });
 
+  it("retains both canonical attribute grouping levels in development fallback data", async () => {
+    const species = await catalogApi.getSpeciesBySlug("gimpel");
+
+    expect(species?.attributes[0]).toMatchObject({
+      category: "Kurzcharakteristik",
+      subcategory: "Aussehen und Körperbau"
+    });
+  });
+
   it("keeps mocked cross-entity links referentially valid", async () => {
     const species = await catalogApi.getSpeciesBySlug("gimpel");
     expect(species).not.toBeNull();

--- a/apps/web/src/lib/catalog/mock-api.test.ts
+++ b/apps/web/src/lib/catalog/mock-api.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it } from "vitest";
 import { catalogApi } from "./mock-api";
 
 describe("MockCatalogApi", () => {
+  it("provides published featured content and data-derived filter types", async () => {
+    const overview = await catalogApi.getOverview();
+    const types = await catalogApi.getCatalogTypes();
+
+    expect(overview.featuredSpecies.map((item) => item.slug)).toEqual(["gimpel", "mauersegler", "gruenspecht"]);
+    expect(overview.featuredPlants.map((item) => item.slug)).toEqual(["acer-campestre", "betula-pendula", "cornus-mas"]);
+    expect(overview.featuredHabitats.map((item) => item.slug)).toEqual(["wild-hecken", "altgrasstreifen", "blumenwiese"]);
+    expect(types.plantTypes).toContain("Gehölz");
+    expect(types.habitatTypes).toContain("Vegetation");
+  });
+
   it("filters catalogues with case-insensitive German search terms", async () => {
     const plants = await catalogApi.listPlants({ q: "FELD-ahorn" });
     const habitats = await catalogApi.listHabitats({ q: "sonnig" });

--- a/apps/web/src/lib/catalog/mock-api.ts
+++ b/apps/web/src/lib/catalog/mock-api.ts
@@ -1,8 +1,10 @@
 import { mockHabitats, mockPlants, mockSpecies } from "./mock-data";
+import { featuredSlugs, selectFeatured, uniquePublishedTypes } from "./featured-content";
 import type {
   CatalogApi,
   CatalogOverview,
   CatalogQuery,
+  CatalogTypes,
   HabitatDetail,
   HabitatSummary,
   PlantDetail,
@@ -23,7 +25,17 @@ export class MockCatalogApi implements CatalogApi {
       speciesCount: 14,
       plantCount: 262,
       habitatCount: 57,
-      featuredSpecies: mockSpecies
+      featuredSpecies: selectFeatured(mockSpecies, featuredSlugs.species),
+      featuredPlants: selectFeatured(mockPlants, featuredSlugs.plants),
+      featuredHabitats: selectFeatured(mockHabitats, featuredSlugs.habitats)
+    };
+  }
+
+  async getCatalogTypes(): Promise<CatalogTypes> {
+    return {
+      speciesTypes: uniquePublishedTypes(mockSpecies),
+      plantTypes: uniquePublishedTypes(mockPlants),
+      habitatTypes: uniquePublishedTypes(mockHabitats)
     };
   }
 

--- a/apps/web/src/lib/catalog/mock-data.ts
+++ b/apps/web/src/lib/catalog/mock-data.ts
@@ -35,6 +35,7 @@ export const mockSpecies: SpeciesDetail[] = [
     attributes: [
       {
         category: "Kurzcharakteristik",
+        subcategory: "Aussehen und Körperbau",
         label: "Aussehen",
         value:
           "Männchen tragen eine leuchtend rote Unterseite und schwarze Kopfplatte. Weibchen sind dezenter graubraun gefärbt.",
@@ -42,12 +43,14 @@ export const mockSpecies: SpeciesDetail[] = [
       },
       {
         category: "Bedeutung für den Menschen",
+        subcategory: "Wahrnehmung",
         label: "Beobachtbarkeit",
         value:
           "Der ruhige Ruf und die markante Silhouette machen den Gimpel zu einer gut erkennbaren Zielart in strukturreichen Freiräumen."
       },
       {
         category: "Kritische Standortfaktoren",
+        subcategory: "Brut und Aufzucht",
         label: "Brut und Aufzucht",
         value:
           "Dichte, ausreichend hohe Hecken und Nadelgehölze bieten geschützte Neststandorte. Eine zu starke Auslichtung ist zu vermeiden.",

--- a/apps/web/src/lib/catalog/postgres-api.ts
+++ b/apps/web/src/lib/catalog/postgres-api.ts
@@ -163,7 +163,7 @@ export class PostgresCatalogApi implements CatalogApi {
     const [summary, lifecycle, attributes, plants, habitats] = await Promise.all([
       this.speciesSummary(row),
       this.database.query("SELECT m.* FROM media_assets m JOIN species_media sm ON sm.media_id=m.id WHERE sm.species_id=$1 AND m.image_type='lifecycle' ORDER BY sm.sort_order, m.created_at LIMIT 1", [row.id]),
-      this.database.query("SELECT d.level1_display_name AS category,d.display_name AS label,v.value,v.sources FROM species_attribute_values v JOIN species_attribute_definitions d ON d.id=v.definition_id WHERE v.species_id=$1 AND nullif(trim(v.value),'') IS NOT NULL ORDER BY d.primary_sort,d.secondary_sort", [row.id]),
+      this.database.query("SELECT d.level1_display_name AS category,COALESCE(NULLIF(BTRIM(d.level2_display_name),''),d.level1_display_name) AS subcategory,d.display_name AS label,v.value,v.sources FROM species_attribute_values v JOIN species_attribute_definitions d ON d.id=v.definition_id WHERE v.species_id=$1 AND nullif(trim(v.value),'') IS NOT NULL ORDER BY d.primary_sort,d.secondary_sort", [row.id]),
       this.database.query("SELECT p.scientific_name,p.common_name,r.purpose FROM species_plant_relations r JOIN plants p ON p.id=r.plant_id WHERE r.species_id=$1 AND p.publication_status='published' ORDER BY p.scientific_name", [row.id]),
       this.database.query("SELECT h.legacy_slug,h.name,r.purpose,r.purpose_element,r.lifecycle_stage FROM species_habitat_relations r JOIN habitat_elements h ON h.id=r.habitat_element_id WHERE r.species_id=$1 AND h.publication_status='published' ORDER BY h.name", [row.id])
     ]);
@@ -179,7 +179,7 @@ export class PostgresCatalogApi implements CatalogApi {
         familyScientific: row.family_scientific || "",
         genusScientific: row.genus_scientific || ""
       },
-      attributes: attributes.rows.map((item) => ({ category: item.category, label: item.label, value: item.value, sources: item.sources || undefined })),
+      attributes: attributes.rows.map((item) => ({ category: item.category, subcategory: item.subcategory, label: item.label, value: item.value, sources: item.sources || undefined })),
       lifecycleImage: imageFromRow(lifecycle.rows[0], row.common_name, "lifecycle"),
       plants: plants.rows.map((item) => ({ slug: catalogSlug(item.scientific_name), scientificName: item.scientific_name, commonName: item.common_name || item.scientific_name, purpose: item.purpose || "" })),
       habitats: habitats.rows.map((item) => ({ slug: catalogSlug(item.legacy_slug), name: item.name, purpose: item.purpose || "", purposeElement: item.purpose_element || "", lifecycleStage: item.lifecycle_stage || "" }))

--- a/apps/web/src/lib/catalog/postgres-api.ts
+++ b/apps/web/src/lib/catalog/postgres-api.ts
@@ -1,10 +1,12 @@
 import "server-only";
 
 import { Pool, type QueryResultRow } from "pg";
+import { featuredSlugs, selectFeatured } from "./featured-content";
 import type {
   CatalogApi,
   CatalogOverview,
   CatalogQuery,
+  CatalogTypes,
   ContentStatus,
   HabitatDetail,
   HabitatSummary,
@@ -128,7 +130,22 @@ export class PostgresCatalogApi implements CatalogApi {
       speciesCount: species.filter((item) => item.status === "published").length,
       plantCount: plants.filter((item) => item.status === "published").length,
       habitatCount: habitats.filter((item) => item.status === "published").length,
-      featuredSpecies: species.filter((item) => item.status === "published").slice(0, 3)
+      featuredSpecies: selectFeatured(species, featuredSlugs.species),
+      featuredPlants: selectFeatured(plants, featuredSlugs.plants),
+      featuredHabitats: selectFeatured(habitats, featuredSlugs.habitats)
+    };
+  }
+
+  async getCatalogTypes(): Promise<CatalogTypes> {
+    const [species, plants, habitats] = await Promise.all([
+      this.database.query<{ value: string }>("SELECT DISTINCT class_common AS value FROM species WHERE publication_status='published' AND nullif(trim(class_common),'') IS NOT NULL ORDER BY value"),
+      this.database.query<{ value: string }>("SELECT DISTINCT plant_type AS value FROM plants WHERE publication_status='published' AND nullif(trim(plant_type),'') IS NOT NULL ORDER BY value"),
+      this.database.query<{ value: string }>("SELECT DISTINCT element_type AS value FROM habitat_elements WHERE publication_status='published' AND nullif(trim(element_type),'') IS NOT NULL ORDER BY value")
+    ]);
+    return {
+      speciesTypes: species.rows.map((row) => row.value),
+      plantTypes: plants.rows.map((row) => row.value),
+      habitatTypes: habitats.rows.map((row) => row.value)
     };
   }
 
@@ -170,7 +187,7 @@ export class PostgresCatalogApi implements CatalogApi {
   }
 
   private plantSummary(row: PlantRow): PlantSummary {
-    const ecologicalValue = row.local_fauna_importance || "Ökologische Bedeutung wird fachlich ergänzt.";
+    const ecologicalValue = row.local_fauna_importance || "Für diese Pflanze sind noch keine Angaben zur ökologischen Bedeutung hinterlegt.";
     return {
       slug: catalogSlug(row.scientific_name),
       scientificName: row.scientific_name,
@@ -199,7 +216,7 @@ export class PostgresCatalogApi implements CatalogApi {
     return {
       ...this.plantSummary(row),
       siteConditions: [],
-      planningNotes: row.local_fauna_importance || "Planungshinweise werden fachlich ergänzt.",
+      planningNotes: row.local_fauna_importance || "Für diese Pflanze sind noch keine zusätzlichen Planungshinweise hinterlegt.",
       sources: [],
       relatedSpecies: related.rows.map((item) => ({ slug: catalogSlug(item.common_name || item.scientific_name), commonName: item.common_name, scientificName: item.scientific_name, purpose: item.purpose || "" }))
     };

--- a/apps/web/src/lib/catalog/types.ts
+++ b/apps/web/src/lib/catalog/types.ts
@@ -62,6 +62,14 @@ export type CatalogOverview = {
   plantCount: number;
   habitatCount: number;
   featuredSpecies: SpeciesSummary[];
+  featuredPlants: PlantSummary[];
+  featuredHabitats: HabitatSummary[];
+};
+
+export type CatalogTypes = {
+  speciesTypes: string[];
+  plantTypes: string[];
+  habitatTypes: string[];
 };
 
 export type PlantSummary = {
@@ -121,6 +129,7 @@ export type CatalogQuery = {
 
 export interface CatalogApi {
   getOverview(): Promise<CatalogOverview>;
+  getCatalogTypes(): Promise<CatalogTypes>;
   listSpecies(query?: CatalogQuery): Promise<SpeciesSummary[]>;
   getSpeciesBySlug(slug: string): Promise<SpeciesDetail | null>;
   listPlants(query?: CatalogQuery): Promise<PlantSummary[]>;

--- a/apps/web/src/lib/catalog/types.ts
+++ b/apps/web/src/lib/catalog/types.ts
@@ -35,6 +35,7 @@ export type RelatedHabitat = {
 
 export type SpeciesAttribute = {
   category: string;
+  subcategory: string;
   label: string;
   value: string;
   sources?: string;

--- a/docs/replacement-app/editorial-system.md
+++ b/docs/replacement-app/editorial-system.md
@@ -31,6 +31,18 @@ Prefer these primitives whenever a pattern appears on more than one route. Entit
 - At narrow widths, section actions move below their headings and catalogue cards become a single column.
 - The supported narrow reference width is 390 px. Touch targets remain at least 44 px where the component is an important action.
 
+## Homepage featured-content policy
+
+Featured content is deterministic without adding a premature editorial-curation schema:
+
+1. only published records are eligible;
+2. `src/lib/catalog/featured-content.ts` defines an explicit ordered slug list for each entity type;
+3. missing preferred records are skipped rather than failing the page;
+4. remaining positions are filled by published records ordered by stable slug;
+5. the mock adapter applies the same selection function as PostgreSQL.
+
+The preferred slug lists are a temporary code-owned editorial choice. Move them into managed content only when the management workflow includes preview, publication and audit behavior.
+
 ## Boundary with management UI
 
 Public primitives use the `editorial-*` namespace. Management components use the existing `management-*` namespace and may share low-level colour tokens only. Editorial typography, cards and motion must not leak into authenticated work screens.


### PR DESCRIPTION
Closes #88
Closes #96
Closes #98
Closes #99

## Outcome
- adds a canonical homepage section for published plants and habitat elements alongside featured species
- introduces a deterministic published-only featured-content policy with stable fallbacks
- derives all species, plant, and habitat type filters from PostgreSQL instead of partial hard-coded lists
- improves catalogue-card hierarchy, content clamping, and distinct missing-media treatments
- removes mock/migration implementation language from public sparse and legal states
- adds the selected editorial species-attribute index with canonical level-one categories and native level-two disclosures
- keeps all attribute values and sources server-rendered in the natural document flow, without an internal scroll container
- integrates a compact species thumbnail, common name, and scientific name into the sticky portrait navigation
- highlights Kurzcharakteristik, Lebenszyklus, or Planungsbausteine according to the currently visible section
- replaces unbounded plant and habitat columns with function-first planning chapters for Nahrung, Schutz und Rückzug, Brut und Nisten, and Schlafplatz
- adds planning-block name search, entity-type and habitat lifecycle-stage filters, live counts, recoverable empty states, and progressive per-chapter reveal
- retains URL-driven catalogue filters, recovery links, loading/error behavior, and the explicit development mock adapter

## Canonical verification
- homepage counts: 14 species / 259 plants / 57 habitat elements
- featured species: Gimpel / Mauersegler / Zauneidechse
- featured plants: Feld-Ahorn / Hänge-Birke
- featured habitats: (Wild-)Hecken / Altgrasstreifen
- Gimpel attribute hierarchy: 48 populated values / 5 level-one categories; Kurzcharakteristik: 22 values / 10 level-two groups
- Gimpel planning data: 53 plant plus 23 habitat relationships; 66 Nahrung, 12 Schutz und Rückzug, 7 Brut und Nisten, and 3 Schlafplatz chapter assignments
- plant facet Einjährige: 11 matching cards
- empty habitat search reset: returns to all 57 cards
- all current PostgreSQL type facets appear in their public filters

## Quality checks
- npm run lint
- npm run typecheck
- npm test (21 tests)
- PostgreSQL production build via npx next build --webpack (345 generated pages)
- browser verification of sticky identity reveal, all three active-section states, editorial attribute navigation, native disclosures, planning search/type/lifecycle filters, empty-state recovery, progressive reveal, and no page overflow
- mock feature/facet selection, canonical attribute grouping, sticky-navigation selection, planning-function normalization/filtering/grouping, and server-rendered progressive content covered by tests

The default Turbopack build currently fails in the local execution environment while binding an internal CSS-processing port; the official webpack build succeeds.

User-owned changes in .gitignore, README.md, and docs/replacement-app/implementation-plan.md were intentionally left out.